### PR TITLE
Android heading font fix + stronger theme typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,14 @@ Defaults live in `defaultMarkdownTheme` and are intentionally neutral so you can
 - `spacing` - Spacing tokens (xs, s, m, l, xl)
 - `fontSizes` - Font sizes (xs, s, m, l, xl, h1-h6)
 - `fontFamilies` - Font families for regular, heading, and mono text
+- `headingWeight` - Optional weight for headings (useful for Android custom fonts)
 - `borderRadius` - Border radius tokens (s, m, l)
 - `showCodeLanguage` - Show/hide code block language labels
+
+**Android custom fonts note:**
+If you use a custom heading font on Android and don’t load a bold variant, set
+`headingWeight: "normal"` (or use the `styles` prop) to avoid fallback to a
+system serif font.
 
 ### Option 5: Minimal Styling Strategy
 

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-markdown",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "High-performance Markdown parser for React Native using Nitro Modules and md4c",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-markdown/src/renderers/heading.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/heading.tsx
@@ -8,14 +8,31 @@ interface HeadingProps {
   style?: TextStyle;
 }
 
+const ANDROID_SYSTEM_FONTS = new Set([
+  "sans-serif",
+  "sans-serif-medium",
+  "sans-serif-light",
+  "sans-serif-condensed",
+  "sans-serif-thin",
+  "serif",
+  "monospace",
+]);
+
 export const Heading: FC<HeadingProps> = ({ level, children, style }) => {
   const { theme } = useMarkdownContext();
+  const headingWeight =
+    theme.headingWeight ??
+    (Platform.OS === "android" &&
+    theme.fontFamilies.heading &&
+    !ANDROID_SYSTEM_FONTS.has(theme.fontFamilies.heading)
+      ? "normal"
+      : "700");
   const styles = useMemo(
     () =>
       StyleSheet.create({
         heading: {
           color: theme.colors.heading,
-          fontWeight: "700",
+          fontWeight: headingWeight,
           marginTop: theme.spacing.xl,
           marginBottom: theme.spacing.m,
           fontFamily: theme.fontFamilies.heading,

--- a/packages/react-native-nitro-markdown/src/theme.ts
+++ b/packages/react-native-nitro-markdown/src/theme.ts
@@ -46,6 +46,7 @@ export interface MarkdownTheme {
     heading: string | undefined;
     mono: string | undefined;
   };
+  headingWeight?: TextStyle["fontWeight"];
   borderRadius: {
     s: number;
     m: number;
@@ -111,6 +112,7 @@ export const defaultMarkdownTheme: MarkdownTheme = {
       default: "monospace",
     }),
   },
+  headingWeight: undefined,
   borderRadius: {
     s: 6,
     m: 10,
@@ -120,9 +122,11 @@ export const defaultMarkdownTheme: MarkdownTheme = {
 };
 
 export type PartialMarkdownTheme = {
-  [K in keyof MarkdownTheme]?: K extends "showCodeLanguage"
+  [K in keyof MarkdownTheme]?: K extends "showCodeLanguage" | "headingWeight"
     ? MarkdownTheme[K]
-    : Partial<MarkdownTheme[K]>;
+    : MarkdownTheme[K] extends object
+      ? Partial<MarkdownTheme[K]>
+      : MarkdownTheme[K];
 };
 
 export type NodeStyleOverrides = Partial<
@@ -176,6 +180,7 @@ export const minimalMarkdownTheme: MarkdownTheme = {
     heading: undefined,
     mono: undefined,
   },
+  headingWeight: undefined,
   borderRadius: {
     s: 0,
     m: 0,
@@ -195,6 +200,7 @@ export const mergeThemes = (
     fontSizes: { ...base.fontSizes, ...partial.fontSizes },
     fontFamilies: { ...base.fontFamilies, ...partial.fontFamilies },
     borderRadius: { ...base.borderRadius, ...partial.borderRadius },
+    headingWeight: partial.headingWeight ?? base.headingWeight,
     showCodeLanguage: partial.showCodeLanguage ?? base.showCodeLanguage,
   };
 };


### PR DESCRIPTION
## Summary
- Prevent Android heading font fallback for custom fonts.
- Add explicit `headingWeight` theme token for full control.
- Strengthen theme typings for IDE/TypeScript users.
- Update README with the new theme option and Android guidance.
- Bump package version to `0.4.1`.

## API Changes (Backward Compatible)
### New theme token
- `headingWeight?: TextStyle["fontWeight"]`

✅ Optional and fully backward‑compatible.

## Migration Guide
If Android headings look serif or inconsistent with custom fonts:

```ts
<Markdown
  theme={{
    headingWeight: "normal", // if you don’t ship a bold variant
  }}
/>
```

If you ship a bold font file:

```ts
<Markdown
  theme={{
    headingWeight: "700",
  }}
/>
```
