### PR TITLE
docs: add release badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
+# react-native-nitro-markdown
+
+[![npm](https://img.shields.io/badge/npm-v0.5.5-orange?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-markdown)
+[![license](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](./LICENSE)
+[![react-native](https://img.shields.io/badge/react--native-%3E%3D0.75-1677a4?style=flat-square)](https://reactnative.dev/)
+[![nitro-modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.5-black?style=flat-square)](https://github.com/mrousavy/nitro)
+
 <p align="center">
   <img src="./readme/demo.gif" alt="react-native-nitro-markdown demo" width="400" />
 </p>
-
-# react-native-nitro-markdown
 
 Native Markdown parsing and rendering for React Native, powered by [md4c](https://github.com/mity/md4c) (C++) through [Nitro Modules](https://github.com/mrousavy/nitro) (JSI).
 
@@ -24,7 +29,7 @@ Native Markdown parsing and rendering for React Native, powered by [md4c](https:
 | Dependency | Version |
 |---|---|
 | React Native | `>=0.75.0` |
-| react-native-nitro-modules | `>=0.35.4` |
+| react-native-nitro-modules | `>=0.35.5` |
 | react-native-mathjax-svg *(optional)* | `>=0.9.0` |
 | react-native-svg *(optional, for math)* | `>=13.0.0` |
 


### PR DESCRIPTION
## Summary
Add release and compatibility badges to the README header.

## Changes
- Moves the package title above the demo image.
- Adds npm, license, React Native, and Nitro Modules badges.
- Aligns README Nitro Modules requirement with the release badge.

## Test
- Documentation-only change.
