### PR TITLE
fix: handle wide math block panning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2026-04-30
+
+### Fixed
+
+- Wide display math now stays within the markdown viewport and can be panned horizontally on iOS and Android.
+- Math SVG sizing now handles MathJax `ex` dimensions, preventing oversized equations from clipping without a usable horizontal viewport.
+- `MarkdownStream` docs now clarify that `updateIntervalMs` only applies to `updateStrategy="interval"` and is ignored by `"raf"`.
+
 ## [0.5.6] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-nitro-markdown
 
-[![npm](https://img.shields.io/badge/npm-v0.5.6-orange?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-markdown)
+[![npm](https://img.shields.io/badge/npm-v0.5.7-orange?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-markdown)
 [![license](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](./LICENSE)
 [![react-native](https://img.shields.io/badge/react--native-%3E%3D0.75-1677a4?style=flat-square)](https://reactnative.dev/)
 [![nitro-modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.5-black?style=flat-square)](https://github.com/mrousavy/nitro)
@@ -53,6 +53,12 @@ For math rendering:
 
 ```bash
 npm install react-native-mathjax-svg react-native-svg
+```
+
+or with Bun:
+
+```bash
+bun add react-native-mathjax-svg react-native-svg
 ```
 
 **Expo** (development build):
@@ -142,10 +148,10 @@ import { MarkdownStream } from "react-native-nitro-markdown";
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `session` | `MarkdownSession` | required | Session supplying streamed text |
-| `updateIntervalMs` | `number` | `50` | Flush interval for `"interval"` strategy |
-| `updateStrategy` | `"interval" \| "raf"` | `"interval"` | Update cadence |
+| `updateIntervalMs` | `number` | `50` | Flush interval for `"interval"` strategy; ignored by `"raf"` |
+| `updateStrategy` | `"interval" \| "raf"` | `"interval"` | `"interval"` uses `updateIntervalMs`; `"raf"` schedules at most once per animation frame |
 | `useTransitionUpdates` | `boolean` | `false` | Wrap updates in `startTransition` |
-| `incrementalParsing` | `boolean` | `true` | Append-optimized incremental AST updates |
+| `incrementalParsing` | `boolean` | `true` | Append-optimized AST updates; disabled automatically when a `beforeParse` plugin is present |
 
 ### `MarkdownSession`
 
@@ -290,6 +296,18 @@ import { Markdown } from "react-native-nitro-markdown";
 ```
 
 Do not pass untrusted HTML directly into a WebView from a renderer. Sanitize or map known tags/attributes to native components.
+
+### Math Rendering
+
+Math parsing is enabled by default. Rendering LaTeX as native SVG requires both optional packages:
+
+```bash
+bun add react-native-mathjax-svg react-native-svg
+```
+
+Without those packages, `math_inline` and `math_block` render as styled plain text fallback.
+
+Inline math (`$...$`) stays inside text flow. Use block math (`$$...$$`) for large formulas; the default `math_block` renderer is horizontally scrollable when the equation is wider than the screen. Custom `math_block` renderers should preserve the same behavior for long display equations.
 
 ### Theme API
 
@@ -487,7 +505,7 @@ Parser and text utilities only -- no React dependencies. Use this for server-sid
 
 ## Performance Tips
 
-- Use `updateStrategy="raf"` for streaming UI updates.
+- Use `updateStrategy="raf"` for frame-aligned streaming UI updates; `updateIntervalMs` is ignored by `"raf"`.
 - Batch `session.append()` calls at 50-100ms intervals rather than per-character.
 - Enable `virtualize="auto"` for long documents and keep `Markdown` as the primary vertical scroller.
 - Memoize custom `plugins`, `renderers`, `theme`, and `styles` objects when they are created inside a component.
@@ -498,6 +516,7 @@ Parser and text utilities only -- no React dependencies. Use this for server-sid
 | Problem | Solution |
 |---|---|
 | Math renders as code-style fallback | Install `react-native-mathjax-svg` and `react-native-svg` |
+| Large inline math overflows text | Use block math (`$$...$$`) for wide formulas; inline math intentionally stays in text flow |
 | iOS build fails after install | Run `pod install` in your iOS directory |
 | Expo app doesn't load native module | Use a development build (`expo prebuild` + `expo run`), not Expo Go |
 | Android heading font weight looks wrong | Set `theme.headingWeight` explicitly |

--- a/apps/example/app/render-stream.tsx
+++ b/apps/example/app/render-stream.tsx
@@ -16,7 +16,7 @@ import { useBottomTabHeight } from "../hooks/use-bottom-tab-height";
 import { EXAMPLE_COLORS } from "../theme";
 
 const TOKEN_DELAY_MS = 150;
-const UI_UPDATE_INTERVAL_MS = 60;
+const RAW_PREVIEW_SYNC_INTERVAL_MS = 60;
 const CHARS_PER_TICK = 12;
 const DEMO_TEXT = `
 ### 🚀 High-Performance Markdown
@@ -193,7 +193,7 @@ export default function TokenStreamScreen() {
     const unsubscribe = session.getSession().addListener(() => {
       pendingRef.current = true;
       if (!timer) {
-        timer = setTimeout(flush, UI_UPDATE_INTERVAL_MS);
+        timer = setTimeout(flush, RAW_PREVIEW_SYNC_INTERVAL_MS);
       }
     });
 
@@ -286,7 +286,6 @@ export default function TokenStreamScreen() {
             ) : (
               <MarkdownStream
                 session={session.getSession()}
-                updateIntervalMs={UI_UPDATE_INTERVAL_MS}
                 updateStrategy="raf"
                 useTransitionUpdates
               />

--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
     },
     "packages/react-native-nitro-markdown": {
       "name": "react-native-nitro-markdown",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.0.0",
         "@types/react": "~19.2.14",

--- a/packages/react-native-nitro-markdown/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-nitro-markdown/android/src/main/AndroidManifest.xml
@@ -1,4 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.nitromarkdown">
-</manifest>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/packages/react-native-nitro-markdown/android/src/main/java/com/nitromarkdown/NitroMarkdownPackage.kt
+++ b/packages/react-native-nitro-markdown/android/src/main/java/com/nitromarkdown/NitroMarkdownPackage.kt
@@ -6,11 +6,13 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 import com.margelo.nitro.com.nitromarkdown.NitroMarkdownOnLoad
 
+@Suppress("OVERRIDE_DEPRECATION")
 class NitroMarkdownPackage : ReactPackage {
     init {
         NitroMarkdownOnLoad.initializeNative()
     }
 
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> = emptyList()
+
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()
 }

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-markdown",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "High-performance Markdown parser for React Native using Nitro Modules and md4c",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -136,7 +136,12 @@
           "esm": true
         }
       ],
-      "typescript"
+      [
+        "typescript",
+        {
+          "tsc": "../../node_modules/.bin/tsc"
+        }
+      ]
     ]
   }
 }

--- a/packages/react-native-nitro-markdown/src/__tests__/math-renderer.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/math-renderer.test.ts
@@ -1,0 +1,103 @@
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { MarkdownContext } from "../MarkdownContext";
+import { MathBlock } from "../renderers/math";
+import { defaultMarkdownTheme } from "../theme";
+
+jest.mock(
+  "react-native-mathjax-svg",
+  () => ({
+    __esModule: true,
+    default: "MathJax",
+    texToSvg: jest.fn(
+      () =>
+        '<svg width="900ex" height="80ex"><path fill="currentColor" /></svg>',
+    ),
+  }),
+  { virtual: true },
+);
+
+jest.mock("react-native-svg", () => ({ SvgFromXml: "SvgFromXml" }));
+
+describe("MathBlock renderer", () => {
+  it("renders block math inside a horizontal scroll container", () => {
+    let renderer: ReactTestRenderer | undefined;
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation((message?: unknown, ...args: unknown[]) => {
+        if (
+          typeof message === "string" &&
+          message.includes("react-test-renderer is deprecated")
+        ) {
+          return;
+        }
+        process.stderr.write(
+          [message, ...args].map((arg) => String(arg)).join(" ") + "\n",
+        );
+      });
+
+    try {
+      act(() => {
+        renderer = create(
+          createElement(
+            MarkdownContext.Provider,
+            {
+              value: {
+                renderers: {},
+                theme: defaultMarkdownTheme,
+                stylingStrategy: "opinionated",
+              },
+            },
+            createElement(MathBlock, {
+              content:
+                "\\frac{\\partial}{\\partial y}(x^2 + y^2) = 2y \\qquad \\text{and more}",
+            }),
+          ),
+        );
+      });
+
+      const svgNodes = renderer!.root.findAllByType("SvgFromXml");
+      expect(svgNodes).toHaveLength(1);
+      expect(svgNodes[0].props.width).toBe(900);
+      expect(svgNodes[0].props.height).toBe(80);
+      expect(svgNodes[0].props.xml).toContain(defaultMarkdownTheme.colors.text);
+
+      const svgFrame = svgNodes[0].parent;
+      expect(svgFrame?.props.style).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ flexShrink: 0 }),
+          expect.objectContaining({ width: 900, height: 80 }),
+        ]),
+      );
+
+      const contentViewport = svgFrame?.parent?.parent;
+      expect(contentViewport?.props.style).toEqual(
+        expect.objectContaining({
+          width: "100%",
+          alignSelf: "stretch",
+          maxWidth: "100%",
+          overflow: "hidden",
+        }),
+      );
+      expect(contentViewport?.props.onMoveShouldSetPanResponder).toEqual(
+        expect.any(Function),
+      );
+
+      const contentTrack = svgFrame?.parent;
+      expect(contentTrack?.props.style).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            alignSelf: "flex-start",
+            alignItems: "center",
+          }),
+          expect.objectContaining({ width: 900 }),
+          expect.objectContaining({
+            transform: [{ translateX: 0 }],
+          }),
+        ]),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react-native-nitro-markdown/src/__tests__/setup.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/setup.ts
@@ -110,6 +110,9 @@ jest.mock("react-native", () => ({
   Text: "Text",
   FlatList: "FlatList",
   ScrollView: "ScrollView",
+  PanResponder: {
+    create: jest.fn((handlers) => ({ panHandlers: handlers })),
+  },
   Image: {
     getSize: jest.fn(),
   },

--- a/packages/react-native-nitro-markdown/src/markdown-stream.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown-stream.tsx
@@ -56,7 +56,8 @@ export type MarkdownStreamProps = {
    */
   session: MarkdownSession;
   /**
-   * Throttle UI updates to avoid re-rendering on every token.
+   * Throttle UI updates when updateStrategy is "interval".
+   * Ignored when updateStrategy is "raf".
    * Defaults to 50ms, which keeps UI responsive while streaming.
    */
   updateIntervalMs?: number;

--- a/packages/react-native-nitro-markdown/src/markdown.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown.tsx
@@ -998,12 +998,16 @@ const getBaseStyles = (theme: MarkdownTheme): BaseStyles => {
 const createBaseStyles = (theme: MarkdownTheme) =>
   StyleSheet.create({
     container: {
+      width: "100%",
+      maxWidth: "100%",
       flexShrink: 1,
     },
     virtualizedList: {
       flex: 1,
     },
     document: {
+      width: "100%",
+      maxWidth: "100%",
       flexShrink: 1,
     },
     errorText: {

--- a/packages/react-native-nitro-markdown/src/renderers/math.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/math.tsx
@@ -1,9 +1,12 @@
-import type { FC, ComponentType } from "react";
+import type { FC, ComponentType, ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   View,
   Text,
+  PanResponder,
   StyleSheet,
   Platform,
+  type LayoutChangeEvent,
   type StyleProp,
   type ViewStyle,
 } from "react-native";
@@ -16,13 +19,25 @@ let MathJaxComponent: ComponentType<{
   color?: string;
   fontCache?: boolean;
   style?: StyleProp<ViewStyle>;
+  width?: number;
+  height?: number;
   children?: string;
 }> | null = null;
+let SvgFromXmlComponent: ComponentType<{
+  xml: string;
+  width?: number;
+  height?: number;
+  style?: StyleProp<ViewStyle>;
+}> | null = null;
+let texToSvg: ((textext: string, fontSize?: number) => string) | null = null;
 
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mathJaxModule = require("react-native-mathjax-svg");
   MathJaxComponent = mathJaxModule.default || mathJaxModule;
+  texToSvg = mathJaxModule.texToSvg ?? null;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  SvgFromXmlComponent = require("react-native-svg").SvgFromXml;
 } catch {
   if (__DEV__) {
     // eslint-disable-next-line no-console
@@ -40,6 +55,147 @@ type MathInlineProps = {
 type MathStyles = ReturnType<typeof createMathStyles>;
 
 const mathStylesCache = new WeakMap<MarkdownTheme, MathStyles>();
+const SVG_WIDTH_PATTERN = /<svg[^>]*\bwidth="([\d.]+)(?:ex|px)"/i;
+const SVG_HEIGHT_PATTERN = /<svg[^>]*\bheight="([\d.]+)(?:ex|px)"/i;
+
+function colorizeSvg(svg: string, color: string | undefined) {
+  return color ? svg.replace(/currentColor/gim, color) : svg;
+}
+
+function createMathSvg(
+  content: string,
+  fontSize: number,
+  color: string | undefined,
+) {
+  if (!texToSvg) return null;
+
+  try {
+    const xml = colorizeSvg(texToSvg(content, fontSize / 2), color);
+    const widthMatch = SVG_WIDTH_PATTERN.exec(xml);
+    const heightMatch = SVG_HEIGHT_PATTERN.exec(xml);
+    if (!widthMatch || !heightMatch) return null;
+
+    const width = Number.parseFloat(widthMatch[1]);
+    const height = Number.parseFloat(heightMatch[1]);
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return null;
+
+    return { xml, width, height };
+  } catch {
+    return null;
+  }
+}
+
+type HorizontalMathViewportProps = {
+  children: ReactNode;
+  contentWidth?: number;
+  style: StyleProp<ViewStyle>;
+  contentStyle: StyleProp<ViewStyle>;
+};
+
+const HorizontalMathViewport: FC<HorizontalMathViewportProps> = ({
+  children,
+  contentWidth,
+  style,
+  contentStyle,
+}) => {
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const [measuredContentWidth, setMeasuredContentWidth] = useState(
+    contentWidth ?? 0,
+  );
+  const [offset, setOffset] = useState(0);
+  const viewportWidthRef = useRef(0);
+  const contentWidthRef = useRef(contentWidth ?? 0);
+  const offsetRef = useRef(0);
+  const gestureStartOffsetRef = useRef(0);
+  const [panHandlers, setPanHandlers] = useState<
+    ReturnType<typeof PanResponder.create>["panHandlers"] | null
+  >(null);
+
+  const setClampedOffset = useCallback((nextOffset: number) => {
+    const maxOffset = Math.max(
+      0,
+      contentWidthRef.current - viewportWidthRef.current,
+    );
+    const clampedOffset = Math.min(0, Math.max(-maxOffset, nextOffset));
+    offsetRef.current = clampedOffset;
+    setOffset(clampedOffset);
+  }, []);
+
+  useEffect(() => {
+    if (typeof contentWidth !== "number") return;
+
+    contentWidthRef.current = contentWidth;
+    setMeasuredContentWidth(contentWidth);
+    setClampedOffset(offsetRef.current);
+  }, [contentWidth, setClampedOffset]);
+
+  const handleViewportLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      viewportWidthRef.current = event.nativeEvent.layout.width;
+      setViewportWidth(viewportWidthRef.current);
+      setClampedOffset(offsetRef.current);
+    },
+    [setClampedOffset],
+  );
+
+  const handleContentLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      if (typeof contentWidth === "number") return;
+
+      contentWidthRef.current = event.nativeEvent.layout.width;
+      setMeasuredContentWidth(contentWidthRef.current);
+      setClampedOffset(offsetRef.current);
+    },
+    [contentWidth, setClampedOffset],
+  );
+
+  useEffect(() => {
+    const responder = PanResponder.create({
+      onMoveShouldSetPanResponder: (_event, gestureState) => {
+        const hasOverflow =
+          contentWidthRef.current > viewportWidthRef.current + 1;
+        const isHorizontal =
+          Math.abs(gestureState.dx) > Math.abs(gestureState.dy) + 4;
+        return hasOverflow && isHorizontal;
+      },
+      onPanResponderGrant: () => {
+        gestureStartOffsetRef.current = offsetRef.current;
+      },
+      onPanResponderMove: (_event, gestureState) => {
+        setClampedOffset(gestureStartOffsetRef.current + gestureState.dx);
+      },
+      onPanResponderTerminationRequest: () => false,
+    });
+
+    setPanHandlers(responder.panHandlers);
+  }, [setClampedOffset]);
+
+  const centeredOffset =
+    measuredContentWidth > 0 && viewportWidth > measuredContentWidth
+      ? (viewportWidth - measuredContentWidth) / 2
+      : 0;
+
+  return (
+    <View
+      style={style}
+      onLayout={handleViewportLayout}
+      pointerEvents="box-only"
+      {...(panHandlers ?? {})}
+    >
+      <View
+        style={[
+          contentStyle,
+          typeof contentWidth === "number" && { width: contentWidth },
+          { transform: [{ translateX: centeredOffset + offset }] },
+        ]}
+        onLayout={handleContentLayout}
+        pointerEvents="none"
+      >
+        {children}
+      </View>
+    </View>
+  );
+};
 
 const createMathStyles = (theme: MarkdownTheme) =>
   StyleSheet.create({
@@ -63,26 +219,49 @@ const createMathStyles = (theme: MarkdownTheme) =>
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
     mathBlockContainer: {
+      width: "100%",
+      maxWidth: "100%",
+      alignSelf: "stretch",
       marginVertical: theme.spacing.m,
       paddingVertical: theme.spacing.l,
       paddingHorizontal: theme.spacing.l,
       backgroundColor: theme.colors.surface,
       borderRadius: theme.borderRadius.l,
-      alignItems: "center",
       borderWidth: 1,
       borderColor: theme.colors.border,
       // Ensure we don't collapse if MathJax fails to report size immediately
       minHeight: 48,
+      overflow: "hidden",
+    },
+    mathBlockScroll: {
+      width: "100%",
+      alignSelf: "stretch",
+      maxWidth: "100%",
+      overflow: "hidden",
+    },
+    mathBlockScrollContent: {
+      alignSelf: "flex-start",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    mathBlockSvg: {
+      backgroundColor: "transparent",
+    },
+    mathBlockSvgFrame: {
+      flexShrink: 0,
     },
     mathBlockFallbackContainer: {
+      width: "100%",
+      maxWidth: "100%",
+      alignSelf: "stretch",
       marginVertical: theme.spacing.m,
       paddingVertical: theme.spacing.m,
       paddingHorizontal: theme.spacing.l,
       backgroundColor: theme.colors.codeBackground,
       borderRadius: theme.borderRadius.m,
-      alignItems: "center",
       borderWidth: 1,
       borderColor: theme.colors.border,
+      overflow: "hidden",
     },
     mathBlockFallback: {
       fontFamily:
@@ -91,6 +270,7 @@ const createMathStyles = (theme: MarkdownTheme) =>
       fontSize: theme.fontSizes.m,
       color: theme.colors.code,
       textAlign: "center",
+      flexShrink: 0,
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
   });
@@ -135,24 +315,65 @@ export const MathBlock: FC<MathBlockProps> = ({ content, style }) => {
 
   if (!content) return null;
 
+  const displayContent = `\\displaystyle ${content}`;
+  const blockSvg =
+    SvgFromXmlComponent &&
+    createMathSvg(displayContent, theme.fontSizes.l, theme.colors.text);
+
+  if (blockSvg && SvgFromXmlComponent) {
+    return (
+      <View style={[styles.mathBlockContainer, style]}>
+        <HorizontalMathViewport
+          style={styles.mathBlockScroll}
+          contentStyle={styles.mathBlockScrollContent}
+          contentWidth={blockSvg.width}
+        >
+          <View
+            style={[
+              styles.mathBlockSvgFrame,
+              { width: blockSvg.width, height: blockSvg.height },
+            ]}
+          >
+            <SvgFromXmlComponent
+              xml={blockSvg.xml}
+              width={blockSvg.width}
+              height={blockSvg.height}
+              style={styles.mathBlockSvg}
+            />
+          </View>
+        </HorizontalMathViewport>
+      </View>
+    );
+  }
+
   if (MathJaxComponent) {
     return (
       <View style={[styles.mathBlockContainer, style]}>
-        <MathJaxComponent
-          fontSize={theme.fontSizes.l}
-          color={theme.colors.text}
-          fontCache={false}
-          style={{ backgroundColor: "transparent" }}
+        <HorizontalMathViewport
+          style={styles.mathBlockScroll}
+          contentStyle={styles.mathBlockScrollContent}
         >
-          {`\\displaystyle ${content}`}
-        </MathJaxComponent>
+          <MathJaxComponent
+            fontSize={theme.fontSizes.l}
+            color={theme.colors.text}
+            fontCache={false}
+            style={{ backgroundColor: "transparent" }}
+          >
+            {displayContent}
+          </MathJaxComponent>
+        </HorizontalMathViewport>
       </View>
     );
   }
 
   return (
     <View style={[styles.mathBlockFallbackContainer, style]}>
-      <Text style={styles.mathBlockFallback}>{content}</Text>
+      <HorizontalMathViewport
+        style={styles.mathBlockScroll}
+        contentStyle={styles.mathBlockScrollContent}
+      >
+        <Text style={styles.mathBlockFallback}>{content}</Text>
+      </HorizontalMathViewport>
     </View>
   );
 };

--- a/packages/react-native-nitro-markdown/src/renderers/paragraph.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/paragraph.tsx
@@ -38,8 +38,11 @@ const stylesCache = new WeakMap<MarkdownTheme, ParagraphStyles>();
 const createStyles = (theme: MarkdownTheme) =>
   StyleSheet.create({
     paragraph: {
+      width: "100%",
+      maxWidth: "100%",
       flexDirection: "row",
       flexWrap: "wrap",
+      flexShrink: 1,
       marginBottom: theme.spacing.l,
       gap: 0,
     },


### PR DESCRIPTION
## Summary
Fixes wide display math rendering so oversized block equations stay inside the markdown viewport and can be panned horizontally on iOS and Android.

## Changes
- Render block math through a bounded horizontal pan viewport.
- Parse MathJax SVG dimensions emitted in `ex` units.
- Constrain default markdown document and paragraph containers.
- Clarify stream update cadence and math rendering docs.
- Bump package version to `0.5.7`.

## Test
- `bun run test -F react-native-nitro-markdown`
- `bun run lint`
- `bun run typecheck`
- Rebuilt and verified example app on iOS simulator and Android emulator.

also related to https://github.com/JoaoPauloCMarra/react-native-nitro-markdown/issues/42