### PR TITLE
Ship Watchman ignore for Android CMake cache

### DIFF
--- a/packages/react-native-nitro-markdown/.watchmanconfig
+++ b/packages/react-native-nitro-markdown/.watchmanconfig
@@ -1,0 +1,6 @@
+{
+  "ignore_dirs": [
+    "android/.cxx",
+    "android/build"
+  ]
+}

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -40,6 +40,7 @@
     "nitrogen",
     "nitro.json",
     "*.podspec",
+    ".watchmanconfig",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",


### PR DESCRIPTION
# Summary
Ships a package-local Watchman config so consumers that watch the installed package do not scan transient Android CMake output.

# Changes
- Add `.watchmanconfig` for Android `.cxx` and build output
- Include the config in the published package files