### PR TITLE
Prepare v0.6.2 release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,7 @@ on:
       release_tag:
         description: Release tag to validate against package.json
         required: false
-        default: v0.6.1
+        default: v0.6.2
       npm_dist_tag:
         description: npm dist-tag to use for dry-run validation
         required: false

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,10 @@
+{
+  "ignore_dirs": [
+    "apps/example/android/.cxx",
+    "apps/example/android/app/.cxx",
+    "apps/example/android/app/build",
+    "apps/example/android/build",
+    "packages/react-native-nitro-markdown/android/.cxx",
+    "packages/react-native-nitro-markdown/android/build"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - 2026-05-13
+## [0.6.2] - 2026-05-14
 
 ### Changed
 
+- Aligned `nitrogen` with `react-native-nitro-modules` at `0.35.6` and updated the example app to `ratex-react-native` `0.1.6`.
+- Example app parser benchmarks now report Nitro average, p50, and p95 across repeated runs.
 - Aligned the example app with current Expo SDK 55 dependency validation by updating `expo` to `~55.0.24`, `expo-build-properties` to `~55.0.14`, and `expo-system-ui` to `~55.0.18`.
-- Updated the manual npm publish workflow dispatch default tag to `v0.6.1`.
+- Updated the manual npm publish workflow dispatch default tag to `v0.6.2`.
 - Aligned the podspec source tag with the repository's `v<version>` release tag format.
+- Exported stronger public TypeScript types for renderer props, table options, image URL safety options, parse-complete results, and parse error phases.
+- Expanded README usage, image safety, session lifecycle, and TypeScript guidance for the current API surface.
 
 ### Fixed
 
+- `useMarkdownSession` now disposes its native session on unmount after clearing the buffer.
+- `MarkdownStream` now tolerates native subscription cleanup failures and avoids scheduling state updates after unmount.
+- iOS `MarkdownSession` now locks `memorySize` reads and clears listener/buffer storage through `dispose()`.
 - iOS `MarkdownSession.replace()` now matches Android by rejecting invalid ranges and reporting clamped listener ranges for out-of-bounds replacements.
+- Built-in renderers now expose basic accessibility semantics for headings, links, images, and task items.
+- Built-in image rendering now rejects unsafe URL protocols by default and supports explicit protocol/host allowlists.
+- Virtualized markdown now defaults `removeClippedSubviews` to Android-only unless explicitly configured.
 - Publish verification now asserts the dry-run package tarball includes expected JS, native, generated, README, license, and Watchman files.
+- The example Metro config and root Watchman config now ignore Android `.cxx` scratch directories created during native CMake builds.
 
 ## [0.6.0] - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-nitro-markdown
 
-[![npm](https://img.shields.io/badge/npm-v0.6.1-orange?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-markdown)
+[![npm](https://img.shields.io/badge/npm-v0.6.2-orange?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-markdown)
 [![license](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](./LICENSE)
 [![react-native](https://img.shields.io/badge/react--native-%3E%3D0.75-1677a4?style=flat-square)](https://reactnative.dev/)
 [![nitro-modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.6-black?style=flat-square)](https://github.com/mrousavy/nitro)
@@ -114,6 +114,7 @@ import { Markdown } from "react-native-nitro-markdown";
 | `onError` | `(error, phase, pluginName?) => void` | -- | Error handler for parse/plugin failures |
 | `highlightCode` | `boolean \| CodeHighlighter` | -- | Enable syntax highlighting for code blocks |
 | `tableOptions` | `{ minColumnWidth?; measurementStabilizeMs? }` | -- | Table layout tuning |
+| `imageOptions` | `UrlSafetyOptions` | `{ allowedProtocols: ["http:", "https:"] }` | Built-in image URL allowlist |
 | `virtualize` | `boolean \| "auto"` | `false` | Top-level block virtualization |
 | `virtualizationMinBlocks` | `number` | `40` | Block threshold for `"auto"` virtualization |
 | `virtualization` | `MarkdownVirtualizationOptions` | -- | FlatList tuning (windowSize, batching, etc.) |
@@ -163,6 +164,7 @@ session.append("Streaming content...");
 | `getTextRange` | `(from, to) => string` | Get substring range |
 | `addListener` | `(listener) => () => void` | Subscribe to mutation events; returns unsubscribe |
 | `highlightPosition` | `number` | Mutable cursor for stream highlight |
+| `dispose` | `() => void` | Release native listener and buffer storage; called automatically by `useMarkdownSession` on unmount |
 
 ### `useMarkdownSession()`
 
@@ -252,6 +254,29 @@ Renderers receive `EnhancedRendererProps` with `node`, `children`, and `Renderer
 | `html_inline`, `html_block` | Read raw HTML from `node.content` |
 
 Return `undefined` to fall back to the built-in renderer, or `null` to render nothing.
+
+TypeScript users can import specific renderer props for stronger IDE feedback:
+
+```tsx
+import type {
+  CustomRenderers,
+  ImageRendererProps,
+  LinkRendererProps,
+  MathRendererProps,
+} from "react-native-nitro-markdown";
+
+const renderers: CustomRenderers = {
+  link: ({ href, children }: LinkRendererProps) => (
+    <MyLink href={href}>{children}</MyLink>
+  ),
+  image: ({ url, alt }: ImageRendererProps) => (
+    <MyImage source={{ uri: url }} accessibilityLabel={alt} />
+  ),
+  math_block: ({ content }: MathRendererProps) => (
+    <MyMathBlock latex={content} />
+  ),
+};
+```
 
 #### Rendering HTML Nodes
 
@@ -473,6 +498,35 @@ const myHighlighter: CodeHighlighter = (language, code) => {
 ```
 
 Default link behavior: trims href, calls `onLinkPress`, validates scheme (`http:`, `https:`, `mailto:`, `tel:`, `sms:`), then opens via `Linking.openURL`. Relative URLs and anchors are ignored unless handled in `onLinkPress`.
+
+### Image URL Safety
+
+Built-in image rendering only loads `http:` and `https:` URLs by default. Use `imageOptions` to narrow the allowed hosts or, when your app owns the source content, add another protocol explicitly.
+
+```tsx
+import { Markdown, type UrlSafetyOptions } from "react-native-nitro-markdown";
+
+const imageOptions: UrlSafetyOptions = {
+  allowedProtocols: ["https:"],
+  allowedHosts: ["cdn.example.com", "images.example.com"],
+};
+
+<Markdown imageOptions={imageOptions}>{content}</Markdown>;
+```
+
+Relative image URLs are not loaded by the default renderer. Map them in a custom `image` renderer when your app has a trusted asset resolver.
+
+### TypeScript Surface
+
+The package exports public types for every commonly customized surface:
+
+- `MarkdownProps`, `MarkdownStreamProps`, `MarkdownParseCompleteResult`, `MarkdownErrorPhase`
+- `MarkdownNode`, `ParserOptions`, `AstTransform`, `MarkdownPlugin`
+- `CustomRenderers`, `CustomRendererPropsByNode`, and node-specific renderer props
+- `MarkdownTheme`, `PartialMarkdownTheme`, `NodeStyleOverrides`, `TableOptions`, `UrlSafetyOptions`
+- `MarkdownSession`, `CodeHighlighter`, `HighlightedToken`, `TokenType`
+
+Prefer typing shared `renderers`, `plugins`, `theme`, `tableOptions`, and `imageOptions` constants instead of relying on inference from inline JSX props. That keeps mistakes visible in IDEs and gives AI-assisted edits a stricter contract to follow.
 
 ## Supported Node Types
 

--- a/apps/example/app/index.tsx
+++ b/apps/example/app/index.tsx
@@ -36,6 +36,7 @@ import { COMPLEX_MARKDOWN } from "../markdown-test-data";
 import { EXAMPLE_COLORS } from "../theme";
 
 const REPEATED_MARKDOWN = COMPLEX_MARKDOWN.repeat(50);
+const NITRO_BENCHMARK_ITERATIONS = 12;
 const LATEX_BENCH_MARKDOWN = Array.from(
   { length: 18 },
   (_, index) => `
@@ -59,6 +60,9 @@ type LatexBenchmarkTarget = {
 
 type BenchmarkResults = {
   nitroTime: number;
+  nitroP50: number;
+  nitroP95: number;
+  nitroIterations: number;
   commonmarkTime: number;
   markdownItTime: number;
   markedTime: number;
@@ -123,6 +127,15 @@ const legacyMathRenderers: CustomRenderers = {
 };
 
 const NATIVE_RUNTIME_PLATFORMS = ["ios", "android"] as const;
+
+const getPercentile = (values: number[], percentile: number): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentile / 100) * sorted.length) - 1),
+  );
+  return sorted[index] ?? 0;
+};
 
 function collectNodeTypes(ast: MarkdownNode): Set<string> {
   const allTypes = new Set<string>();
@@ -697,12 +710,24 @@ export default function BenchmarkScreen() {
   const wait = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
 
-  const runNitroBenchmark = (): number => {
+  const runNitroBenchmark = () => {
     parseMarkdown("warmup");
-    const startNitro = global.performance.now();
-    parseMarkdown(REPEATED_MARKDOWN);
-    const endNitro = global.performance.now();
-    return endNitro - startNitro;
+    const samples: number[] = [];
+
+    for (let index = 0; index < NITRO_BENCHMARK_ITERATIONS; index++) {
+      const startNitro = global.performance.now();
+      parseMarkdown(REPEATED_MARKDOWN);
+      const endNitro = global.performance.now();
+      samples.push(endNitro - startNitro);
+    }
+
+    const total = samples.reduce((sum, sample) => sum + sample, 0);
+    return {
+      average: total / samples.length,
+      p50: getPercentile(samples, 50),
+      p95: getPercentile(samples, 95),
+      iterations: samples.length,
+    };
   };
 
   const measureLatexRenderer = (
@@ -752,7 +777,7 @@ export default function BenchmarkScreen() {
     try {
       await wait(100);
 
-      const nitroTime = runNitroBenchmark();
+      const nitroBenchmark = runNitroBenchmark();
       await wait(100);
 
       const commonmarkParser = new Parser();
@@ -783,7 +808,10 @@ export default function BenchmarkScreen() {
 
       const ratexTime = await measureLatexRenderer("ratex");
       setBenchmarkResults({
-        nitroTime,
+        nitroTime: nitroBenchmark.average,
+        nitroP50: nitroBenchmark.p50,
+        nitroP95: nitroBenchmark.p95,
+        nitroIterations: nitroBenchmark.iterations,
         commonmarkTime,
         markdownItTime,
         markedTime,
@@ -864,7 +892,16 @@ export default function BenchmarkScreen() {
               <View style={styles.metricRow}>
                 <Text style={styles.metricName}>Nitro C++</Text>
                 <Text style={[styles.metricValue, styles.metricPrimary]}>
-                  {benchmarkResults.nitroTime.toFixed(2)}ms
+                  {benchmarkResults.nitroTime.toFixed(2)}ms avg
+                </Text>
+              </View>
+              <View style={styles.metricRow}>
+                <Text style={styles.metricName}>
+                  Nitro p50 / p95 ({benchmarkResults.nitroIterations}x)
+                </Text>
+                <Text style={styles.metricValue}>
+                  {benchmarkResults.nitroP50.toFixed(2)} /{" "}
+                  {benchmarkResults.nitroP95.toFixed(2)}ms
                 </Text>
               </View>
               <View style={styles.metricRow}>

--- a/apps/example/metro.config.js
+++ b/apps/example/metro.config.js
@@ -8,6 +8,9 @@ const config = getDefaultConfig(projectRoot);
 
 const defaultWatchFolders = config.watchFolders ?? [];
 const defaultBlockList = config.resolver.blockList;
+const normalizePathForRegex = (value) =>
+  value.replace(/[/\\^$*+?.()|[\]{}]/g, "\\$&");
+const monorepoRootPattern = normalizePathForRegex(monorepoRoot);
 
 // Keep Expo defaults and add the monorepo root.
 config.watchFolders = Array.from(
@@ -31,7 +34,7 @@ config.resolver.extraNodeModules = {
 
 config.resolver.blockList = [
   ...(Array.isArray(defaultBlockList) ? defaultBlockList : [defaultBlockList]).filter(Boolean),
-  /node_modules\/react-native-nitro-modules\/android\/\.cxx\/.*/,
+  new RegExp(`${monorepoRootPattern}[/\\\\].*[/\\\\]\\.cxx[/\\\\].*`),
 ];
 
 module.exports = config;

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -24,7 +24,7 @@
     "expo-router": "~55.0.14",
     "expo-status-bar": "~55.0.6",
     "expo-system-ui": "~55.0.18",
-    "ratex-react-native": "0.1.4",
+    "ratex-react-native": "0.1.6",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "jest": "^29.7.0",
         "markdown-it": "^14.1.1",
         "marked": "^17.0.6",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.6",
         "react": "19.2.0",
         "react-native": "0.83.6",
         "react-native-builder-bob": "^0.41.0",
@@ -46,7 +46,7 @@
         "expo-router": "~55.0.14",
         "expo-status-bar": "~55.0.6",
         "expo-system-ui": "~55.0.18",
-        "ratex-react-native": "0.1.4",
+        "ratex-react-native": "0.1.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.6",
@@ -72,7 +72,7 @@
     },
     "packages/react-native-nitro-markdown": {
       "name": "react-native-nitro-markdown",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.0.0",
         "@types/react": "~19.2.14",
@@ -1665,7 +1665,7 @@
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
-    "nitrogen": ["nitrogen@0.35.5", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.5", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-Ofl4aTW2rd44+hBcUwLXu01ViHikn2SDI7zOYc+6NcKSpnhoj42k1FwyvRj1QZPDMUT64Bwlb0DYw7Hrfd3BfQ=="],
+    "nitrogen": ["nitrogen@0.35.6", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.6", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-fUoyqCEQugl49L/lp/v3LceZt8jwL/gqfLhWsxRPxr1pOTnBhyrcEJ2dAJvHl10h7JxaswP6YCnVZMZmjJavKg=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
@@ -1803,7 +1803,7 @@
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
-    "ratex-react-native": ["ratex-react-native@0.1.4", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-6lYq0g+ojUEFUL/o5C6kFx0ltGfCbIaWEVVuVavm1+h/+XmmUDbv/QzmXrRasHL6nKMi4si3xmRJH7kTZXI5eA=="],
+    "ratex-react-native": ["ratex-react-native@0.1.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-TyNejUrJDaeE0VP0/2aRcGcrTHFm6jAdi3jsopwZnbk4MoB4VPPhmJLwHmnYeJtb76HC1q/PvlDUVNS8v0oIdA=="],
 
     "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jest": "^29.7.0",
     "markdown-it": "^14.1.1",
     "marked": "^17.0.6",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.6",
     "react": "19.2.0",
     "react-native": "0.83.6",
     "react-native-builder-bob": "^0.41.0",

--- a/packages/react-native-nitro-markdown/android/src/main/java/com/margelo/nitro/com/nitromarkdown/HybridMarkdownSession.kt
+++ b/packages/react-native-nitro-markdown/android/src/main/java/com/margelo/nitro/com/nitromarkdown/HybridMarkdownSession.kt
@@ -19,8 +19,14 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
 
     @GuardedBy("lock")
     override var highlightPosition: Double = 0.0
-        get() = synchronized(lock) { field }
-        set(value) = synchronized(lock) { field = value }
+        get() = synchronized(lock) {
+            checkActiveLocked()
+            field
+        }
+        set(value) = synchronized(lock) {
+            checkActiveLocked()
+            field = value
+        }
         // No notify for highlighting to avoid flood
 
     override val memorySize: Long
@@ -30,6 +36,7 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
         val from: Int
         val to: Int
         synchronized(lock) {
+            checkActiveLocked()
             if (buffer.length + chunk.length > MAX_BUFFER_SIZE) {
                 throw IllegalArgumentException("Buffer size limit exceeded (max ${MAX_BUFFER_SIZE} chars)")
             }
@@ -43,6 +50,7 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
 
     override fun clear() {
         synchronized(lock) {
+            checkActiveLocked()
             buffer.clear()
             highlightPosition = 0.0
         }
@@ -51,12 +59,14 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
 
     override fun getAllText(): String {
         synchronized(lock) {
+            checkActiveLocked()
             return buffer.toString()
         }
     }
 
     override fun getLength(): Double {
         synchronized(lock) {
+            checkActiveLocked()
             return buffer.length.toDouble()
         }
     }
@@ -64,6 +74,7 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
     override fun getTextRange(from: Double, to: Double): String {
         if (!from.isFinite() || !to.isFinite() || from < 0.0 || to < 0.0 || from > to) return ""
         synchronized(lock) {
+            checkActiveLocked()
             val start = from.toLong().coerceIn(0L, buffer.length.toLong()).toInt()
             val end = to.toLong().coerceIn(start.toLong(), buffer.length.toLong()).toInt()
             return buffer.substring(start, end)
@@ -72,7 +83,7 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
 
     override fun addListener(listener: (Double, Double) -> Unit): () -> Unit {
         synchronized(lock) {
-            if (isDestroyed) throw IllegalStateException("HybridMarkdownSession is destroyed")
+            checkActiveLocked()
             val id = nextListenerId++
             listeners[id] = listener
             return { synchronized(lock) { listeners.remove(id) } }
@@ -81,6 +92,7 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
 
     override fun reset(text: String) {
         synchronized(lock) {
+            checkActiveLocked()
             if (text.length > MAX_BUFFER_SIZE) {
                 throw IllegalArgumentException("Buffer size limit exceeded (max $MAX_BUFFER_SIZE chars)")
             }
@@ -98,6 +110,7 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
         val notifyFrom: Double
         val notifyTo: Double
         synchronized(lock) {
+            checkActiveLocked()
             val start = from.toLong().coerceIn(0L, buffer.length.toLong()).toInt()
             val end = to.toLong().coerceIn(start.toLong(), buffer.length.toLong()).toInt()
             val newSize = buffer.length - (end - start) + text.length
@@ -125,6 +138,11 @@ class HybridMarkdownSession : HybridMarkdownSessionSpec() {
                 android.util.Log.e(TAG, "Listener callback threw an exception", e)
             }
         }
+    }
+
+    @GuardedBy("lock")
+    private fun checkActiveLocked() {
+        if (isDestroyed) throw IllegalStateException("HybridMarkdownSession is destroyed")
     }
 
     fun onDestroyed() {

--- a/packages/react-native-nitro-markdown/ios/HybridMarkdownSession.swift
+++ b/packages/react-native-nitro-markdown/ios/HybridMarkdownSession.swift
@@ -6,19 +6,49 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
 
     private var buffer = ""
     private var listeners: [UUID: (Double, Double) -> Void] = [:]
+    private var isDisposed = false
     private let lock = NSLock()
 
     var highlightPosition: Double {
-        get { lock.lock(); defer { lock.unlock() }; return _highlightPosition }
-        set { lock.lock(); defer { lock.unlock() }; _highlightPosition = newValue }
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            if isDisposed { return 0 }
+            return _highlightPosition
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            if isDisposed { return }
+            _highlightPosition = newValue
+        }
     }
     private var _highlightPosition: Double = 0
 
     var memorySize: Int {
+        lock.lock()
+        defer { lock.unlock() }
         return buffer.utf8.count
             + MemoryLayout<HybridMarkdownSession>.size
             + MemoryLayout<NSLock>.size
             + listeners.count * 128  // UUID key (16 bytes) + closure overhead estimate
+    }
+
+    deinit {
+        releaseStorage()
+    }
+
+    func dispose() {
+        releaseStorage()
+    }
+
+    private func releaseStorage() {
+        lock.lock()
+        defer { lock.unlock() }
+        listeners.removeAll()
+        buffer = ""
+        _highlightPosition = 0
+        isDisposed = true
     }
 
     private func utf16Length(_ value: String) -> Int {
@@ -43,6 +73,7 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
         do {
             lock.lock()
             defer { lock.unlock() }
+            try validateActiveLocked()
             let fromInt = utf16Length(buffer)
             try validateBufferSize(fromInt + utf16Length(chunk))
             buffer += chunk
@@ -58,6 +89,7 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
         do {
             lock.lock()
             defer { lock.unlock() }
+            try validateActiveLocked()
             buffer = ""
             _highlightPosition = 0
         }
@@ -67,12 +99,14 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
     func getAllText() throws -> String {
         lock.lock()
         defer { lock.unlock() }
+        try validateActiveLocked()
         return buffer
     }
 
     func getLength() throws -> Double {
         lock.lock()
         defer { lock.unlock() }
+        try validateActiveLocked()
         return Double(utf16Length(buffer))
     }
 
@@ -82,6 +116,7 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
         }
         lock.lock()
         defer { lock.unlock() }
+        try validateActiveLocked()
 
         let text = buffer as NSString
         let length = text.length
@@ -97,8 +132,9 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
     func addListener(listener: @escaping (Double, Double) -> Void) throws -> () -> Void {
         let id = UUID()
         lock.lock()
+        defer { lock.unlock() }
+        try validateActiveLocked()
         listeners[id] = listener
-        lock.unlock()
 
         return { [weak self] in
             guard let self else { return }
@@ -113,6 +149,7 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
         do {
             lock.lock()
             defer { lock.unlock() }
+            try validateActiveLocked()
             try validateBufferSize(utf16Length(text))
             buffer = text
             _highlightPosition = 0
@@ -130,6 +167,7 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
         do {
             lock.lock()
             defer { lock.unlock() }
+            try validateActiveLocked()
             guard from.isFinite && to.isFinite && from >= 0 && to >= 0 && from <= to else {
                 throw NSError(
                     domain: "NitroMarkdown",
@@ -152,6 +190,18 @@ class HybridMarkdownSession: HybridMarkdownSessionSpec {
         }
         notifyListeners(from: notifyFrom, to: notifyTo)
         return newLength
+    }
+
+    private func validateActiveLocked() throws {
+        if isDisposed {
+            throw NSError(
+                domain: "NitroMarkdown",
+                code: 3,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "HybridMarkdownSession is destroyed"
+                ]
+            )
+        }
     }
 
     /// Notifies all registered listeners about a buffer change.

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-markdown",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "High-performance Markdown parser for React Native using Nitro Modules and md4c",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-markdown/src/MarkdownContext.ts
+++ b/packages/react-native-nitro-markdown/src/MarkdownContext.ts
@@ -12,6 +12,7 @@ import {
   type StylingStrategy,
 } from "./theme";
 import type { CodeHighlighter } from "./utils/code-highlight";
+import type { UrlSafetyOptions } from "./utils/link-security";
 
 export type NodeRendererProps = {
   node: MarkdownNode;
@@ -72,19 +73,60 @@ export type TaskListItemRendererProps = {
   checked: boolean;
 } & BaseCustomRendererProps;
 
-export type CustomRendererProps = {} & EnhancedRendererProps;
+export type MathRendererProps = {
+  content: string;
+} & BaseCustomRendererProps;
+
+export type CustomRendererProps = EnhancedRendererProps;
 
 export type LinkPressHandler = (
   href: string,
 ) => void | boolean | Promise<void | boolean>;
 
-export type CustomRenderer = (
-  props: EnhancedRendererProps,
-) => ReactNode | undefined;
+export type CustomRenderer<
+  Props extends EnhancedRendererProps = EnhancedRendererProps,
+> = (props: Props) => ReactNode | undefined;
 
-export type CustomRenderers = Partial<
-  Record<MarkdownNode["type"], CustomRenderer>
->;
+export type CustomRendererPropsByNode = {
+  document: CustomRendererProps;
+  heading: HeadingRendererProps;
+  paragraph: CustomRendererProps;
+  text: CustomRendererProps;
+  bold: CustomRendererProps;
+  italic: CustomRendererProps;
+  strikethrough: CustomRendererProps;
+  link: LinkRendererProps;
+  image: ImageRendererProps;
+  code_inline: InlineCodeRendererProps;
+  code_block: CodeBlockRendererProps;
+  blockquote: CustomRendererProps;
+  horizontal_rule: CustomRendererProps;
+  line_break: CustomRendererProps;
+  soft_break: CustomRendererProps;
+  table: CustomRendererProps;
+  table_head: CustomRendererProps;
+  table_body: CustomRendererProps;
+  table_row: CustomRendererProps;
+  table_cell: CustomRendererProps;
+  list: ListRendererProps;
+  list_item: CustomRendererProps;
+  task_list_item: TaskListItemRendererProps;
+  math_inline: MathRendererProps;
+  math_block: MathRendererProps;
+  html_block: CustomRendererProps;
+  html_inline: CustomRendererProps;
+};
+
+export type CustomRenderers = Partial<{
+  [Type in MarkdownNode["type"]]: CustomRenderer<
+    CustomRendererPropsByNode[Type]
+  >;
+}>;
+
+export type TableOptions = {
+  minColumnWidth?: number;
+  measurementStabilizeMs?: number;
+};
 
 export type MarkdownContextValue = {
   renderers: CustomRenderers;
@@ -93,10 +135,8 @@ export type MarkdownContextValue = {
   stylingStrategy: StylingStrategy;
   onLinkPress?: LinkPressHandler;
   highlightCode?: boolean | CodeHighlighter;
-  tableOptions?: {
-    minColumnWidth?: number;
-    measurementStabilizeMs?: number;
-  };
+  tableOptions?: TableOptions;
+  imageOptions?: UrlSafetyOptions;
 };
 
 export const MarkdownContext = createContext<MarkdownContextValue>({

--- a/packages/react-native-nitro-markdown/src/__tests__/link-security.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/link-security.test.ts
@@ -1,4 +1,8 @@
-import { normalizeLinkHref, getAllowedExternalHref } from "../utils/link-security";
+import {
+  normalizeLinkHref,
+  getAllowedExternalHref,
+  getAllowedImageHref,
+} from "../utils/link-security";
 
 describe("normalizeLinkHref", () => {
   it("returns null for empty string", () => {
@@ -11,6 +15,10 @@ describe("normalizeLinkHref", () => {
 
   it("trims whitespace", () => {
     expect(normalizeLinkHref("  https://example.com  ")).toBe("https://example.com");
+  });
+
+  it("rejects control characters", () => {
+    expect(normalizeLinkHref("https://example.com/\nnext")).toBeNull();
   });
 
   it("returns non-empty href as-is", () => {
@@ -36,5 +44,42 @@ describe("getAllowedExternalHref", () => {
   it("rejects links without explicit protocol", () => {
     expect(getAllowedExternalHref("example.com")).toBeNull();
     expect(getAllowedExternalHref("/relative/path")).toBeNull();
+  });
+});
+
+describe("getAllowedImageHref", () => {
+  it.each(["https://example.com/image.png", "http://example.com/image.png"])(
+    "allows %s by default",
+    (href) => {
+      expect(getAllowedImageHref(href)).toBe(href);
+    },
+  );
+
+  it.each(["data:image/png;base64,abc", "file:///tmp/image.png", "javascript:alert(1)"])(
+    "rejects %s by default",
+    (href) => {
+      expect(getAllowedImageHref(href)).toBeNull();
+    },
+  );
+
+  it("allows configured protocols", () => {
+    expect(
+      getAllowedImageHref("data:image/png;base64,abc", {
+        allowedProtocols: ["https", "data"],
+      }),
+    ).toBe("data:image/png;base64,abc");
+  });
+
+  it("filters configured hosts", () => {
+    expect(
+      getAllowedImageHref("https://assets.example.com/image.png", {
+        allowedHosts: ["assets.example.com"],
+      }),
+    ).toBe("https://assets.example.com/image.png");
+    expect(
+      getAllowedImageHref("https://evil.example.com/image.png", {
+        allowedHosts: ["assets.example.com"],
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/react-native-nitro-markdown/src/__tests__/markdown-stream.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/markdown-stream.test.ts
@@ -52,15 +52,18 @@ function createSession({
 
 describe("MarkdownStream", () => {
   let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.useFakeTimers();
     markdownMock.mockClear();
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
     jest.useRealTimers();
   });
 
@@ -148,5 +151,44 @@ describe("MarkdownStream", () => {
     expect(markdownMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ children: "hello brave world" }),
     );
+  });
+
+  it("does not throw when a destroyed session rejects subscription", () => {
+    const session = createSession({
+      allText: "hello",
+      rangeText: "",
+    });
+    session.addListener = jest.fn(() => {
+      throw new Error("destroyed");
+    });
+
+    expect(() => {
+      act(() => {
+        TestRenderer.create(React.createElement(MarkdownStream, { session }));
+      });
+    }).not.toThrow();
+  });
+
+  it("does not throw when native unsubscription fails during cleanup", () => {
+    const session = createSession({
+      allText: "hello",
+      rangeText: "",
+    });
+    const unsubscribe = jest.fn(() => {
+      throw new Error("unsubscribe failed");
+    });
+    session.addListener = jest.fn(() => unsubscribe);
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(MarkdownStream, { session }));
+    });
+
+    expect(() => {
+      act(() => {
+        renderer!.unmount();
+      });
+    }).not.toThrow();
+    expect(unsubscribe).toHaveBeenCalled();
   });
 });

--- a/packages/react-native-nitro-markdown/src/__tests__/renderer-accessibility.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/renderer-accessibility.test.ts
@@ -1,0 +1,106 @@
+import "./setup";
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { Markdown } from "../markdown";
+import type { MarkdownNode } from "../headless";
+
+jest.mock("../renderers/math", () => ({
+  MathInline: "MathInline",
+  MathBlock: "MathBlock",
+}));
+
+const sourceAst: MarkdownNode = {
+  type: "document",
+  children: [
+    {
+      type: "heading",
+      level: 2,
+      children: [{ type: "text", content: "Title" }],
+    },
+    {
+      type: "paragraph",
+      children: [
+        {
+          type: "link",
+          href: "https://example.com",
+          children: [{ type: "text", content: "Example" }],
+        },
+      ],
+    },
+    {
+      type: "list",
+      children: [
+        {
+          type: "task_list_item",
+          checked: true,
+          children: [{ type: "text", content: "Done" }],
+        },
+      ],
+    },
+    {
+      type: "image",
+      href: "javascript:alert(1)",
+      alt: "Unsafe image",
+    },
+  ],
+};
+
+function renderMarkdown(ast: MarkdownNode, props: Record<string, unknown> = {}) {
+  let renderer: ReactTestRenderer | null = null;
+  const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+  try {
+    act(() => {
+      renderer = create(
+        createElement(Markdown, { sourceAst: ast, ...props }, "ignored"),
+      );
+    });
+    return renderer!;
+  } finally {
+    consoleErrorSpy.mockRestore();
+  }
+}
+
+describe("Markdown renderer accessibility", () => {
+  it("wires semantic roles for built-in renderers", () => {
+    const renderer = renderMarkdown(sourceAst);
+
+    expect(
+      renderer.root.findAll(
+        (node) => node.type === "Text" && node.props.accessibilityRole === "header",
+      ),
+    ).toHaveLength(1);
+    expect(
+      renderer.root.findAll(
+        (node) => node.type === "Text" && node.props.accessibilityRole === "link",
+      ),
+    ).toHaveLength(1);
+    expect(
+      renderer.root.findAll(
+        (node) =>
+          node.type === "View" &&
+          node.props.accessibilityRole === "checkbox" &&
+          node.props.accessibilityState?.checked === true,
+      ),
+    ).toHaveLength(1);
+    expect(
+      renderer.root.findAll(
+        (node) =>
+          node.type === "View" &&
+          node.props.accessibilityRole === "image" &&
+          node.props.accessibilityLabel === "Unsafe image",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("defaults clipped subview removal to false on iOS virtualization", () => {
+    const children = Array.from({ length: 45 }, (_, index): MarkdownNode => ({
+      type: "paragraph",
+      children: [{ type: "text", content: `Paragraph ${index}` }],
+    }));
+    const renderer = renderMarkdown({ type: "document", children }, { virtualize: true });
+
+    const list = renderer.root.findByType("FlatList");
+    expect(list.props.removeClippedSubviews).toBe(false);
+  });
+});

--- a/packages/react-native-nitro-markdown/src/__tests__/session.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/session.test.ts
@@ -1,7 +1,28 @@
 import "./setup";
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { NitroModules } from "react-native-nitro-modules";
 import { createMarkdownSession } from "../MarkdownSession";
+import { useMarkdownSession } from "../use-markdown-stream";
+
+const createHybridObjectMock = NitroModules.createHybridObject as jest.Mock;
+
+function SessionOwner() {
+  useMarkdownSession();
+  return null;
+}
 
 describe("createMarkdownSession", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   it("creates a session without throwing", () => {
     expect(() => createMarkdownSession()).not.toThrow();
   });
@@ -31,5 +52,39 @@ describe("createMarkdownSession", () => {
     expect(() => session.replace(-1, 0, "!")).toThrow("Invalid range");
     expect(() => session.replace(2, 1, "!")).toThrow("Invalid range");
     expect(session.getAllText()).toBe("hello");
+  });
+
+  it("disposes hook-owned sessions on unmount", () => {
+    createHybridObjectMock.mockClear();
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(SessionOwner));
+    });
+
+    const session = createHybridObjectMock.mock.results[0].value;
+
+    act(() => {
+      renderer!.unmount();
+    });
+
+    expect(session.clear).toHaveBeenCalled();
+    expect(session.dispose).toHaveBeenCalled();
+  });
+
+  it("rejects session use after dispose", () => {
+    const session = createMarkdownSession();
+
+    session.append("hello");
+    session.dispose();
+
+    expect(() => session.append("!")).toThrow("destroyed");
+    expect(() => session.clear()).toThrow("destroyed");
+    expect(() => session.getAllText()).toThrow("destroyed");
+    expect(() => session.getLength()).toThrow("destroyed");
+    expect(() => session.getTextRange(0, 1)).toThrow("destroyed");
+    expect(() => session.reset("new")).toThrow("destroyed");
+    expect(() => session.replace(0, 0, "new")).toThrow("destroyed");
+    expect(() => session.addListener(() => undefined)).toThrow("destroyed");
   });
 });

--- a/packages/react-native-nitro-markdown/src/__tests__/setup.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/setup.ts
@@ -102,8 +102,15 @@ const mockParser = {
 function createMockSession() {
   let buffer = "";
   let highlightPosition = 0;
+  let isDisposed = false;
   const listeners = new Map<number, (from: number, to: number) => void>();
   let nextListenerId = 0;
+
+  const assertActive = () => {
+    if (isDisposed) {
+      throw new Error("HybridMarkdownSession is destroyed");
+    }
+  };
 
   const notify = (from: number, to: number) => {
     for (const listener of listeners.values()) {
@@ -113,20 +120,34 @@ function createMockSession() {
 
   return {
     append: jest.fn((chunk: string) => {
+      assertActive();
       const from = buffer.length;
       buffer += chunk;
       notify(from, buffer.length);
       return buffer.length;
     }),
     clear: jest.fn(() => {
+      assertActive();
       buffer = "";
       highlightPosition = 0;
       notify(0, 0);
     }),
-    dispose: jest.fn(),
-    getAllText: jest.fn(() => buffer),
-    getLength: jest.fn(() => buffer.length),
+    dispose: jest.fn(() => {
+      isDisposed = true;
+      listeners.clear();
+      buffer = "";
+      highlightPosition = 0;
+    }),
+    getAllText: jest.fn(() => {
+      assertActive();
+      return buffer;
+    }),
+    getLength: jest.fn(() => {
+      assertActive();
+      return buffer.length;
+    }),
     getTextRange: jest.fn((from: number, to: number) => {
+      assertActive();
       if (!Number.isFinite(from) || !Number.isFinite(to) || from < 0 || to < 0 || from > to) {
         return "";
       }
@@ -138,14 +159,17 @@ function createMockSession() {
       return highlightPosition;
     },
     set highlightPosition(value: number) {
+      assertActive();
       highlightPosition = value;
     },
     reset: jest.fn((text: string) => {
+      assertActive();
       buffer = text;
       highlightPosition = 0;
       notify(0, buffer.length);
     }),
     replace: jest.fn((from: number, to: number, text: string) => {
+      assertActive();
       if (!Number.isFinite(from) || !Number.isFinite(to) || from < 0 || to < 0 || from > to) {
         throw new Error(
           `Invalid range: from=${from} and to=${to} must be finite, from must be >= 0, and to must be >= from`,
@@ -158,6 +182,7 @@ function createMockSession() {
       return buffer.length;
     }),
     addListener: jest.fn((listener: (from: number, to: number) => void) => {
+      assertActive();
       const id = nextListenerId++;
       listeners.set(id, listener);
       return () => {

--- a/packages/react-native-nitro-markdown/src/index.ts
+++ b/packages/react-native-nitro-markdown/src/index.ts
@@ -15,6 +15,8 @@ export type {
   MarkdownProps,
   AstTransform,
   MarkdownPlugin,
+  MarkdownErrorPhase,
+  MarkdownParseCompleteResult,
   MarkdownVirtualizationOptions,
 } from "./markdown";
 export { MarkdownStream } from "./markdown-stream";
@@ -35,8 +37,11 @@ export type {
   InlineCodeRendererProps,
   ListRendererProps,
   TaskListItemRendererProps,
+  MathRendererProps,
   LinkPressHandler,
   MarkdownContextValue,
+  CustomRendererPropsByNode,
+  TableOptions,
 } from "./MarkdownContext";
 
 export {
@@ -72,3 +77,4 @@ export type {
   CodeHighlighter,
 } from "./utils/code-highlight";
 export { defaultHighlighter } from "./utils/code-highlight";
+export type { UrlSafetyOptions } from "./utils/link-security";

--- a/packages/react-native-nitro-markdown/src/markdown-stream.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown-stream.tsx
@@ -58,6 +58,15 @@ const resolveStreamText = ({
   return session.getAllText();
 };
 
+function warnStreamError(message: string, error: unknown): void {
+  if (!__DEV__) return;
+
+  const warn = Reflect.get(console, "warn");
+  if (typeof warn === "function") {
+    warn.call(console, message, error);
+  }
+}
+
 export type MarkdownStreamProps = {
   /**
    * The active MarkdownSession to stream content from.
@@ -124,11 +133,19 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
   const forceFullSyncRef = useRef(false);
   const updateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rafRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
   const allowIncremental = incrementalParsing && !hasBeforeParsePlugins;
 
   useEffect(() => {
     renderStateRef.current = renderState;
   }, [renderState]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     const initialText = session.getAllText();
@@ -185,9 +202,11 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
         ast: nextAst,
       };
       renderStateRef.current = nextState;
+      if (!mountedRef.current) return;
 
       if (useTransitionUpdates) {
         startTransition(() => {
+          if (!mountedRef.current) return;
           setRenderState(nextState);
         });
       } else {
@@ -208,28 +227,41 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
       }
     };
 
-    const unsubscribe = session.addListener((from, to) => {
-      const nextFrom = normalizeOffset(from);
-      const nextTo = normalizeOffset(to);
+    let unsubscribe: (() => void) | null = null;
 
-      if (nextFrom === null || nextTo === null || nextTo < nextFrom) {
-        forceFullSyncRef.current = true;
-      } else {
-        const currentFrom = pendingFromRef.current;
-        const currentTo = pendingToRef.current;
+    try {
+      unsubscribe = session.addListener((from, to) => {
+        const nextFrom = normalizeOffset(from);
+        const nextTo = normalizeOffset(to);
 
-        pendingFromRef.current =
-          currentFrom === null ? nextFrom : Math.min(currentFrom, nextFrom);
-        pendingToRef.current =
-          currentTo === null ? nextTo : Math.max(currentTo, nextTo);
-      }
+        if (nextFrom === null || nextTo === null || nextTo < nextFrom) {
+          forceFullSyncRef.current = true;
+        } else {
+          const currentFrom = pendingFromRef.current;
+          const currentTo = pendingToRef.current;
 
-      pendingUpdateRef.current = true;
-      scheduleFlush();
-    });
+          pendingFromRef.current =
+            currentFrom === null ? nextFrom : Math.min(currentFrom, nextFrom);
+          pendingToRef.current =
+            currentTo === null ? nextTo : Math.max(currentTo, nextTo);
+        }
+
+        pendingUpdateRef.current = true;
+        scheduleFlush();
+      });
+    } catch (error) {
+      warnStreamError("[NitroMarkdown] Failed to subscribe to stream:", error);
+    }
 
     return () => {
-      unsubscribe();
+      try {
+        unsubscribe?.();
+      } catch (error) {
+        warnStreamError(
+          "[NitroMarkdown] Failed to unsubscribe from stream:",
+          error,
+        );
+      }
       if (updateTimerRef.current) {
         clearTimeout(updateTimerRef.current);
         updateTimerRef.current = null;

--- a/packages/react-native-nitro-markdown/src/markdown.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown.tsx
@@ -31,9 +31,11 @@ import type { ParserOptions } from "./Markdown.nitro";
 import {
   MarkdownContext,
   useMarkdownContext,
+  type CustomRenderer,
   type CustomRenderers,
   type LinkPressHandler,
   type NodeRendererProps,
+  type TableOptions,
 } from "./MarkdownContext";
 import { Blockquote } from "./renderers/blockquote";
 import { CodeBlock, InlineCode } from "./renderers/code";
@@ -55,6 +57,7 @@ import {
   type StylingStrategy,
 } from "./theme";
 import type { CodeHighlighter } from "./utils/code-highlight";
+import type { UrlSafetyOptions } from "./utils/link-security";
 
 function hashString(str: string): number {
   let hash = 0;
@@ -142,6 +145,14 @@ export type MarkdownPlugin = {
    * Optional AST postprocessor executed after native parsing.
    */
   afterParse?: AstTransform;
+};
+
+export type MarkdownErrorPhase = "parse" | "before-plugin" | "after-plugin";
+
+export type MarkdownParseCompleteResult = {
+  raw: string;
+  ast: MarkdownNode;
+  text: string;
 };
 
 const isMarkdownNode = (value: unknown): value is MarkdownNode => {
@@ -355,11 +366,7 @@ export type MarkdownProps = {
   /**
    * Callback fired when parsing completes.
    */
-  onParseComplete?: (result: {
-    raw: string;
-    ast: MarkdownNode;
-    text: string;
-  }) => void;
+  onParseComplete?: (result: MarkdownParseCompleteResult) => void;
   /**
    * Called when a parse error or plugin error occurs.
    * @param error - The thrown error.
@@ -368,7 +375,7 @@ export type MarkdownProps = {
    */
   onError?: (
     error: Error,
-    phase: "parse" | "before-plugin" | "after-plugin",
+    phase: MarkdownErrorPhase,
     pluginName?: string,
   ) => void;
   /**
@@ -426,10 +433,8 @@ export type MarkdownProps = {
   /**
    * Optional configuration for the table renderer.
    */
-  tableOptions?: {
-    minColumnWidth?: number;
-    measurementStabilizeMs?: number;
-  };
+  tableOptions?: TableOptions;
+  imageOptions?: UrlSafetyOptions;
   /**
    * Enable built-in syntax highlighting for code blocks.
    * Pass `true` to use the built-in tokenizer, or a custom highlighter function.
@@ -457,6 +462,7 @@ export const Markdown: FC<MarkdownProps> = ({
   virtualizationMinBlocks = 40,
   virtualization,
   tableOptions,
+  imageOptions,
   highlightCode,
 }) => {
   const parserOptionGfm = options?.gfm;
@@ -563,6 +569,7 @@ export const Markdown: FC<MarkdownProps> = ({
       stylingStrategy,
       onLinkPress,
       tableOptions,
+      imageOptions,
       highlightCode,
     }),
     [
@@ -572,6 +579,7 @@ export const Markdown: FC<MarkdownProps> = ({
       stylingStrategy,
       onLinkPress,
       tableOptions,
+      imageOptions,
       highlightCode,
     ],
   );
@@ -625,7 +633,7 @@ export const Markdown: FC<MarkdownProps> = ({
               virtualization?.updateCellsBatchingPeriod ?? 16
             }
             removeClippedSubviews={
-              virtualization?.removeClippedSubviews ?? true
+              virtualization?.removeClippedSubviews ?? Platform.OS === "android"
             }
             bounces={false}
             alwaysBounceVertical={false}
@@ -747,7 +755,7 @@ const NodeRendererComponent: FC<NodeRendererProps> = ({
     return elements;
   };
 
-  const customRenderer = renderers[node.type];
+  const customRenderer = renderers[node.type] as CustomRenderer | undefined;
   if (customRenderer) {
     const childrenRendered = renderChildren(
       node.children,

--- a/packages/react-native-nitro-markdown/src/renderers/heading.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/heading.tsx
@@ -34,7 +34,11 @@ export const Heading: FC<HeadingProps> = ({ level, children, style }) => {
     level === 6 && styles.h6,
   ];
 
-  return <Text style={[...headingStyles, style]}>{children}</Text>;
+  return (
+    <Text style={[...headingStyles, style]} accessibilityRole="header">
+      {children}
+    </Text>
+  );
 };
 
 type HeadingStyles = ReturnType<typeof createStyles>;

--- a/packages/react-native-nitro-markdown/src/renderers/image.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/image.tsx
@@ -16,6 +16,7 @@ import {
 } from "react-native";
 import { parseMarkdownWithOptions, type MarkdownNode } from "../headless";
 import { useMarkdownContext } from "../MarkdownContext";
+import { getAllowedImageHref } from "../utils/link-security";
 import type { NodeRendererProps } from "../MarkdownContext";
 
 const renderInlineContent = (
@@ -46,7 +47,11 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [aspectRatio, setAspectRatio] = useState<number | undefined>(undefined);
-  const { theme } = useMarkdownContext();
+  const { theme, imageOptions } = useMarkdownContext();
+  const allowedImageHref = useMemo(
+    () => getAllowedImageHref(url, imageOptions),
+    [imageOptions, url],
+  );
 
   const styles = useMemo(
     () =>
@@ -113,10 +118,18 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
   useEffect(() => {
     let isMounted = true;
     setLoading(true);
-    setError(false);
+    setError(!allowedImageHref);
     setAspectRatio(undefined);
 
-    const picsumMatch = url.match(/picsum\.photos\/.*\/(\d+)\/(\d+)/);
+    if (!allowedImageHref) {
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const picsumMatch = allowedImageHref.match(
+      /picsum\.photos\/.*\/(\d+)\/(\d+)/,
+    );
     if (picsumMatch) {
       const w = parseInt(picsumMatch[1], 10);
       const h = parseInt(picsumMatch[2], 10);
@@ -129,7 +142,7 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
     }
 
     RNImage.getSize(
-      url,
+      allowedImageHref,
       (width, height) => {
         if (isMounted && width > 0 && height > 0) {
           setAspectRatio(width / height);
@@ -149,7 +162,7 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
     return () => {
       isMounted = false;
     };
-  }, [url]);
+  }, [allowedImageHref]);
 
   const altContent = useMemo(() => {
     if (!alt || !Renderer) return null;
@@ -180,9 +193,16 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
     return <Text style={styles.imageErrorText}>{alt}</Text>;
   }, [alt, Renderer, styles.imageErrorText]);
 
-  if (error) {
+  const accessibilityLabel = alt || title;
+
+  if (error || !allowedImageHref) {
     return (
-      <View style={[styles.imageError, style]}>
+      <View
+        style={[styles.imageError, style]}
+        accessible={Boolean(accessibilityLabel)}
+        accessibilityRole={accessibilityLabel ? "image" : undefined}
+        accessibilityLabel={accessibilityLabel}
+      >
         <View
           style={{
             flexDirection: "row",
@@ -210,9 +230,12 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
         </View>
       ) : null}
       <RNImage
-        source={{ uri: url }}
+        source={{ uri: allowedImageHref ?? "" }}
         style={[styles.image, loading && !aspectRatio && styles.imageHidden]}
         resizeMode="contain"
+        accessible={Boolean(accessibilityLabel)}
+        accessibilityRole={accessibilityLabel ? "image" : undefined}
+        accessibilityLabel={accessibilityLabel}
         onLoad={() => {
           setLoading(false);
         }}

--- a/packages/react-native-nitro-markdown/src/renderers/link.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/link.tsx
@@ -59,7 +59,11 @@ export const Link: FC<LinkProps> = ({ href, children, style }) => {
   };
 
   return (
-    <Text style={[styles.link, style]} onPress={handlePress}>
+    <Text
+      style={[styles.link, style]}
+      onPress={handlePress}
+      accessibilityRole="link"
+    >
       {children}
     </Text>
   );

--- a/packages/react-native-nitro-markdown/src/renderers/list.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/list.tsx
@@ -71,7 +71,11 @@ export const TaskListItem: FC<TaskListItemProps> = ({
     createTaskListItemStyles,
   );
   return (
-    <View style={[styles.taskListItem, style]}>
+    <View
+      style={[styles.taskListItem, style]}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked }}
+    >
       <View
         style={[styles.taskCheckbox, checked && styles.taskCheckboxChecked]}
       >

--- a/packages/react-native-nitro-markdown/src/use-markdown-stream.ts
+++ b/packages/react-native-nitro-markdown/src/use-markdown-stream.ts
@@ -19,7 +19,15 @@ export function useMarkdownSession() {
   useEffect(() => {
     const session = sessionRef.current!;
     return () => {
-      session.clear();
+      try {
+        session.clear();
+      } finally {
+        try {
+          session.dispose();
+        } finally {
+          sessionRef.current = null;
+        }
+      }
     };
   }, []);
 

--- a/packages/react-native-nitro-markdown/src/utils/link-security.ts
+++ b/packages/react-native-nitro-markdown/src/utils/link-security.ts
@@ -6,17 +6,81 @@ const ALLOWED_LINK_PROTOCOLS = new Set([
   "sms:",
 ]);
 
+const DEFAULT_IMAGE_PROTOCOLS = ["http:", "https:"] as const;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F]/;
+
+export type UrlSafetyOptions = {
+  allowedProtocols?: readonly string[];
+  allowedHosts?: readonly string[];
+};
+
 export const normalizeLinkHref = (href: string): string | null => {
   const normalizedHref = href.trim();
+  if (CONTROL_CHARACTER_PATTERN.test(normalizedHref)) return null;
   return normalizedHref.length > 0 ? normalizedHref : null;
 };
 
-export const getAllowedExternalHref = (href: string): string | null => {
+const parseAbsoluteHref = (
+  href: string,
+): { protocol: string; hostname: string } | null => {
   const protocolMatch = href.match(/^([a-z][a-z0-9+.-]*):/i);
   if (!protocolMatch) return null;
 
-  const protocol = `${protocolMatch[1].toLowerCase()}:`;
-  if (!ALLOWED_LINK_PROTOCOLS.has(protocol)) return null;
+  const protocol = normalizeProtocol(protocolMatch[1]);
+  const rest = href.slice(protocolMatch[0].length);
+  const authorityMatch = rest.match(/^\/\/([^/?#]*)/);
+  const rawHost = authorityMatch?.[1] ?? "";
+  const hostname = rawHost
+    .replace(/^[^@]*@/, "")
+    .replace(/^\[|\]$/g, "")
+    .split(":")[0]
+    .toLowerCase();
 
-  return href;
+  return { protocol, hostname };
+};
+
+const normalizeProtocol = (protocol: string): string => {
+  const normalized = protocol.trim().toLowerCase();
+  return normalized.endsWith(":") ? normalized : `${normalized}:`;
+};
+
+export const getAllowedExternalHref = (href: string): string | null => {
+  const normalizedHref = normalizeLinkHref(href);
+  if (!normalizedHref) return null;
+
+  const parsed = parseAbsoluteHref(normalizedHref);
+  if (!parsed) return null;
+
+  if (!ALLOWED_LINK_PROTOCOLS.has(parsed.protocol)) return null;
+
+  return normalizedHref;
+};
+
+export const getAllowedImageHref = (
+  href: string,
+  options?: UrlSafetyOptions,
+): string | null => {
+  const normalizedHref = normalizeLinkHref(href);
+  if (!normalizedHref) return null;
+
+  const parsed = parseAbsoluteHref(normalizedHref);
+  if (!parsed) return null;
+
+  const allowedProtocols = new Set(
+    (options?.allowedProtocols ?? DEFAULT_IMAGE_PROTOCOLS).map(
+      normalizeProtocol,
+    ),
+  );
+  if (!allowedProtocols.has(parsed.protocol)) return null;
+
+  const allowedHosts = options?.allowedHosts;
+  if (allowedHosts && allowedHosts.length > 0) {
+    const normalizedHost = parsed.hostname.toLowerCase();
+    const allowedHostSet = new Set(
+      allowedHosts.map((host) => host.trim().toLowerCase()).filter(Boolean),
+    );
+    if (!allowedHostSet.has(normalizedHost)) return null;
+  }
+
+  return normalizedHref;
 };


### PR DESCRIPTION
# Summary
Prepare react-native-nitro-markdown v0.6.2 with lifecycle cleanup, renderer safety, dependency alignment, and release documentation updates.

# Changes
- Bump package version to 0.6.2 and align release workflow defaults, README badge, changelog, and lockfile metadata.
- Update Nitro/RaTeX dependencies and add repeated Nitro benchmark stats in the example app.
- Dispose MarkdownSession instances on unmount and harden iOS/Android session cleanup after disposal.
- Make MarkdownStream tolerate subscription cleanup failures and avoid post-unmount state updates.
- Add image URL protocol/host allowlists, renderer accessibility semantics, and Android-only default clipping for virtualized markdown.
- Export stronger public TypeScript types for renderer props, table options, image safety options, parse results, and error phases.
- Ignore Android CMake scratch directories in Watchman and Metro to remove build-time ENOENT log noise.