### PR TITLE
Fix markdown stream disposal races

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,7 @@ on:
       release_tag:
         description: Release tag to validate against package.json
         required: false
-        default: v0.7.1
+        default: v0.7.2
       npm_dist_tag:
         description: npm dist-tag to use for dry-run validation
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.7.2] - 2026-06-10
+
+### Added
+
+- Exported `MarkdownRenderers` as a public alias for `CustomRenderers` so custom renderer examples and IDE completions use a stable package type.
 
 ### Fixed
 
 - `MarkdownStream` no longer throws when a pending stream update races with hook-owned session disposal during navigation.
 - `MarkdownStream` now reuses stable parsed AST nodes across full-parse stream updates to reduce rerenders during markdown-heavy streams.
+- `MarkdownStream` now keeps parser option identity stable by value, preventing unnecessary session resubscriptions when callers pass inline parser options.
+- The example stream screen now isolates raw text preview updates from the markdown render subtree, reducing React commits during active token streaming.
+- README usage examples now match the exported TypeScript API for parser options, source AST rendering, HTML parsing, and custom renderers.
 
 ## [0.7.1] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MarkdownStream` no longer throws when a pending stream update races with hook-owned session disposal during navigation.
 - `MarkdownStream` now reuses stable parsed AST nodes across full-parse stream updates to reduce rerenders during markdown-heavy streams.
 - `MarkdownStream` now keeps parser option identity stable by value, preventing unnecessary session resubscriptions when callers pass inline parser options.
-- The example stream screen now isolates raw text preview updates from the markdown render subtree, reducing React commits during active token streaming.
+- The example stream screen now keeps the native stream session alive across tab switches while deferring expensive markdown rendering until the screen is focused again.
+- The example stream screen now isolates and caps raw text preview updates, reducing React commits and retained preview memory during active token streaming.
 - README usage examples now match the exported TypeScript API for parser options, source AST rendering, HTML parsing, and custom renderers.
 
 ## [0.7.1] - 2026-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `MarkdownStream` no longer throws when a pending stream update races with hook-owned session disposal during navigation.
+- `MarkdownStream` now reuses stable parsed AST nodes across full-parse stream updates to reduce rerenders during markdown-heavy streams.
+
 ## [0.7.1] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 Markdown parsing, rendering, streaming, and headless AST access for React
 Native, powered by md4c and Nitro Modules.
 
-Use it when you need GitHub-flavored Markdown, custom renderers, streaming
-chat/LLM output, syntax highlighting, math rendering, or native headless parsing
-without building your own renderer pipeline.
+Use it when you need GitHub-flavored Markdown, custom native renderers,
+streaming chat or LLM output, syntax highlighting, math rendering, or headless
+AST access without building your own parser pipeline.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/JoaoPauloCMarra/react-native-nitro-markdown/main/readme/demo.gif" alt="react-native-nitro-markdown demo" width="400" />
@@ -53,7 +53,7 @@ import { Markdown } from "react-native-nitro-markdown";
 
 export function Article() {
   return (
-    <Markdown options={{ gfm: true }}>
+    <Markdown options={{ gfm: true, math: true }}>
       {"# Hello\nThis is **native** markdown."}
     </Markdown>
   );
@@ -63,13 +63,18 @@ export function Article() {
 ## Streaming
 
 ```tsx
+import { useEffect } from "react";
 import {
   MarkdownStream,
   useMarkdownSession,
 } from "react-native-nitro-markdown";
 
 export function ChatMessage({ text }: { text: string }) {
-  const session = useMarkdownSession(text);
+  const session = useMarkdownSession();
+
+  useEffect(() => {
+    session.reset(text);
+  }, [session, text]);
 
   return (
     <MarkdownStream session={session} updateStrategy="raf" incrementalParsing />
@@ -77,7 +82,19 @@ export function ChatMessage({ text }: { text: string }) {
 }
 ```
 
-`MarkdownStream` batches updates for append-only text. If any plugin uses
+For token-by-token output, append to the hook-owned session and let
+`MarkdownStream` subscribe to range updates:
+
+```tsx
+const session = useMarkdownSession();
+
+session.getSession().append("Hello ");
+session.getSession().append("**world**");
+```
+
+`MarkdownStream` batches updates for append-only text. Use
+`updateStrategy="raf"` for visual streaming, or `updateStrategy="interval"` with
+`updateIntervalMs={50}` to bound update frequency. If any plugin uses
 `beforeParse`, incremental AST optimization is disabled so the full pipeline can
 run correctly. `MarkdownStream` accepts the controller returned by
 `useMarkdownSession()`. Pass `session.getSession()` only when another API needs
@@ -93,8 +110,8 @@ import {
 } from "react-native-nitro-markdown/headless";
 
 const ast = parseMarkdown("# Title");
-const astWithOffsets = parseMarkdownWithOptions("# Title", {
-  sourceAst: true,
+const astWithMath = parseMarkdownWithOptions("Inline $x^2$", {
+  math: true,
 });
 const text = extractPlainText("Hello **world**");
 ```
@@ -102,22 +119,43 @@ const text = extractPlainText("Hello **world**");
 Use the `react-native-nitro-markdown/headless` export when you need AST data,
 plain text extraction, indexing, validation, or tests without rendering UI.
 
+## Source AST Rendering
+
+If you already have a `MarkdownNode`, pass it through the `sourceAst` prop to
+skip native parsing during render:
+
+```tsx
+import {
+  Markdown,
+  parseMarkdown,
+  type MarkdownNode,
+} from "react-native-nitro-markdown";
+
+const ast: MarkdownNode = parseMarkdown("# Cached AST", { gfm: true });
+
+<Markdown sourceAst={ast}>{"# Cached AST"}</Markdown>;
+```
+
+When `sourceAst` is provided, `beforeParse` plugins are skipped because parsing
+already happened. `afterParse` plugins and `astTransform` still run.
+
 ## Common Options
 
-| Option          | Default           | What it does                                              |
-| --------------- | ----------------- | --------------------------------------------------------- |
-| `gfm`           | `true`            | Enables tables, strikethrough, task lists, and autolinks. |
-| `parseCache`    | `true`            | Reuses parsed ASTs for repeated content.                  |
-| `sourceAst`     | `false`           | Includes source offsets for tooling and editor features.  |
-| `allowHtml`     | `false`           | Preserves raw HTML nodes for custom renderers.            |
-| `highlightCode` | `false`           | Enables built-in syntax highlighting.                     |
-| `tableOptions`  | Built-in defaults | Controls table measurement and minimum widths.            |
+| Prop or parser option | Default           | What it does                                              |
+| --------------------- | ----------------- | --------------------------------------------------------- |
+| `options.gfm`         | `true`            | Enables tables, strikethrough, task lists, and autolinks. |
+| `options.math`        | `true`            | Parses inline and block math nodes.                       |
+| `options.html`        | `false`           | Preserves raw HTML nodes for custom renderers.            |
+| `parseCache`          | `true`            | Reuses parsed ASTs for repeated content.                  |
+| `sourceAst`           | `undefined`       | Renders a pre-parsed AST instead of parsing `children`.   |
+| `highlightCode`       | `false`           | Enables built-in syntax highlighting.                     |
+| `tableOptions`        | Built-in defaults | Controls table measurement and minimum widths.            |
 
 ## Custom Rendering
 
 ```tsx
-import type { MarkdownRenderers } from "react-native-nitro-markdown";
-import { Markdown } from "react-native-nitro-markdown";
+import { Text } from "react-native";
+import { Markdown, type MarkdownRenderers } from "react-native-nitro-markdown";
 
 const renderers: MarkdownRenderers = {
   paragraph({ children }) {
@@ -130,6 +168,16 @@ const renderers: MarkdownRenderers = {
 
 Custom renderers receive parsed nodes and pre-mapped props for common node
 types. For `html_inline` and `html_block`, read `node.content` directly.
+
+For stronger component-local typing, use the node-specific renderer props:
+
+```tsx
+import type { CodeBlockRendererProps } from "react-native-nitro-markdown";
+
+function CodeBlock({ content, language }: CodeBlockRendererProps) {
+  return <Text>{`${language ?? "text"}: ${content}`}</Text>;
+}
+```
 
 ## Plugin Pipeline
 
@@ -148,9 +196,51 @@ const plugins: MarkdownPlugin[] = [
 ```
 
 Pipeline order: `beforeParse` plugins, parse or `sourceAst`, `afterParse`
-plugins, `astTransform`, then render. When `sourceAst` is provided, `beforeParse` plugins are skipped
-because parsing already happened. Higher `priority` values run first, and
-sorting is stable.
+plugins, `astTransform`, then render. Higher `priority` values run first, and
+sorting is stable. `onError` receives `(error, phase, pluginName?)` for parser
+and plugin failures.
+
+## TypeScript Guidance
+
+The public types are exported from the root package and the headless subpath.
+Prefer package types over local object shapes so editors and AI tools can catch
+invalid parser options, node names, renderer props, and stream session usage.
+
+```tsx
+import { Text } from "react-native";
+import type {
+  CustomRendererPropsByNode,
+  MarkdownNode,
+  MarkdownPlugin,
+  MarkdownRenderers,
+  MarkdownStreamProps,
+  ParserOptions,
+} from "react-native-nitro-markdown";
+
+const options: ParserOptions = { gfm: true, math: true, html: false };
+
+function HeadingRenderer({
+  children,
+  level,
+}: CustomRendererPropsByNode["heading"]) {
+  return <Text accessibilityRole="header">{`${level}. ${children}`}</Text>;
+}
+
+const renderers: MarkdownRenderers = {
+  heading: HeadingRenderer,
+};
+
+const plugin: MarkdownPlugin = {
+  name: "strip-tracking",
+  afterParse(ast: MarkdownNode) {
+    return ast;
+  },
+};
+
+const streamProps: Pick<MarkdownStreamProps, "updateStrategy"> = {
+  updateStrategy: "raf",
+};
+```
 
 ## API
 
@@ -163,9 +253,9 @@ Main export:
 - `defaultMarkdownTheme` and theme types.
 - Renderer components such as `Paragraph`, `Heading`, `Link`, `CodeBlock`,
   `List`, `Table`, and `Image`.
-- Types including `MarkdownNode`, `MarkdownPlugin`, `MarkdownRenderers`,
-  `ParserOptions`, `MarkdownTheme`, `MarkdownSessionController`, and
-  `MarkdownStreamProps`.
+- Types including `MarkdownNode`, `MarkdownPlugin`, `CustomRenderers`,
+  `MarkdownRenderers`, `CustomRendererPropsByNode`, `ParserOptions`,
+  `MarkdownTheme`, `MarkdownSessionController`, and `MarkdownStreamProps`.
 
 Headless export:
 

--- a/apps/example/app/_layout.tsx
+++ b/apps/example/app/_layout.tsx
@@ -20,6 +20,7 @@ function RootTabs() {
       <Tabs
         screenOptions={{
           headerShown: false,
+          freezeOnBlur: true,
           tabBarStyle: {
             position: "absolute",
             left: 0,

--- a/apps/example/app/render-stream.tsx
+++ b/apps/example/app/render-stream.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { memo, useState, useEffect, useRef, useCallback } from "react";
 import {
   View,
   Text,
@@ -95,6 +95,54 @@ We hope you enjoy using **Nitro Markdown**. It is designed to be the *definitive
 Happy Coding! 
 `;
 
+type MarkdownRendererPanelProps = {
+  session: ReturnType<typeof useMarkdownSession>;
+  hasContent: boolean;
+};
+
+const MarkdownRendererPanel = memo(function MarkdownRendererPanel({
+  session,
+  hasContent,
+}: MarkdownRendererPanelProps) {
+  const markdownScrollViewRef = useRef<ScrollView>(null);
+
+  const handleContentSizeChange = useCallback(() => {
+    markdownScrollViewRef.current?.scrollToEnd({ animated: false });
+  }, []);
+
+  return (
+    <ExamplePanel style={[styles.card, styles.markdownCard]}>
+      <ScrollView
+        ref={markdownScrollViewRef}
+        style={styles.cardScroll}
+        nestedScrollEnabled
+        bounces={false}
+        alwaysBounceVertical={false}
+        overScrollMode="never"
+        contentContainerStyle={styles.scrollContent}
+        onContentSizeChange={handleContentSizeChange}
+      >
+        {!hasContent ? (
+          <View style={styles.placeholder}>
+            <Ionicons
+              name="code-slash-outline"
+              size={32}
+              color={EXAMPLE_COLORS.textMuted}
+            />
+            <Text style={styles.placeholderText}>Waiting for tokens...</Text>
+          </View>
+        ) : (
+          <MarkdownStream
+            session={session}
+            updateStrategy="raf"
+            useTransitionUpdates
+          />
+        )}
+      </ScrollView>
+    </ExamplePanel>
+  );
+});
+
 export default function TokenStreamScreen() {
   const tabHeight = useBottomTabHeight();
 
@@ -187,30 +235,13 @@ export default function TokenStreamScreen() {
   }, []);
 
   const rawScrollViewRef = useRef<ScrollView>(null);
-  const markdownScrollViewRef = useRef<ScrollView>(null);
-  const autoScrollFrameRef = useRef<number | null>(null);
-
-  const scheduleAutoScroll = useCallback(() => {
-    if (autoScrollFrameRef.current !== null) return;
-
-    autoScrollFrameRef.current = requestAnimationFrame(() => {
-      autoScrollFrameRef.current = null;
-      rawScrollViewRef.current?.scrollToEnd({ animated: false });
-      markdownScrollViewRef.current?.scrollToEnd({ animated: false });
-    });
+  const handleRawContentSizeChange = useCallback(() => {
+    rawScrollViewRef.current?.scrollToEnd({ animated: false });
   }, []);
 
   useEffect(() => {
     rawTextRef.current = rawText;
   }, [rawText]);
-
-  useEffect(() => {
-    return () => {
-      if (autoScrollFrameRef.current !== null) {
-        cancelAnimationFrame(autoScrollFrameRef.current);
-      }
-    };
-  }, []);
 
   useEffect(() => {
     const pendingRef = { current: false };
@@ -228,9 +259,6 @@ export default function TokenStreamScreen() {
       }
       setStreamOffset(streamOffsetRef.current);
 
-      if (isStreamMode) {
-        scheduleAutoScroll();
-      }
     };
 
     let unsubscribe: (() => void) | null = null;
@@ -253,7 +281,7 @@ export default function TokenStreamScreen() {
       unsubscribe?.();
       if (timer) clearTimeout(timer);
     };
-  }, [session, isStreamMode, scheduleAutoScroll, getSessionText]);
+  }, [session, getSessionText]);
 
   return (
     <ExampleScreen paddingBottom={0} style={styles.screenContent}>
@@ -319,6 +347,7 @@ export default function TokenStreamScreen() {
             alwaysBounceVertical={false}
             overScrollMode="never"
             contentContainerStyle={styles.scrollContent}
+            onContentSizeChange={handleRawContentSizeChange}
           >
             {rawText.length === 0 ? (
               <Text style={styles.placeholderText}>Waiting for input...</Text>
@@ -329,36 +358,10 @@ export default function TokenStreamScreen() {
         </ExamplePanel>
 
         <ExampleSectionLabel>Markdown Renderer</ExampleSectionLabel>
-        <ExamplePanel style={[styles.card, styles.markdownCard]}>
-          <ScrollView
-            ref={markdownScrollViewRef}
-            style={styles.cardScroll}
-            nestedScrollEnabled
-            bounces={false}
-            alwaysBounceVertical={false}
-            overScrollMode="never"
-            contentContainerStyle={styles.scrollContent}
-          >
-            {rawText.length === 0 ? (
-              <View style={styles.placeholder}>
-                <Ionicons
-                  name="code-slash-outline"
-                  size={32}
-                  color={EXAMPLE_COLORS.textMuted}
-                />
-                <Text style={styles.placeholderText}>
-                  Waiting for tokens...
-                </Text>
-              </View>
-            ) : (
-              <MarkdownStream
-                session={session}
-                updateStrategy="raf"
-                useTransitionUpdates
-              />
-            )}
-          </ScrollView>
-        </ExamplePanel>
+        <MarkdownRendererPanel
+          session={session}
+          hasContent={rawText.length > 0}
+        />
       </ScrollView>
     </ExampleScreen>
   );

--- a/apps/example/app/render-stream.tsx
+++ b/apps/example/app/render-stream.tsx
@@ -5,7 +5,9 @@ import {
   StyleSheet,
   ScrollView,
   Platform,
+  InteractionManager,
 } from "react-native";
+import { useFocusEffect } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import {
   useMarkdownSession,
@@ -23,6 +25,7 @@ import { EXAMPLE_COLORS } from "../theme";
 
 const TOKEN_DELAY_MS = 150;
 const RAW_PREVIEW_SYNC_INTERVAL_MS = 60;
+const RAW_PREVIEW_MAX_CHARS = 3000;
 const CHARS_PER_TICK = 12;
 const DEMO_TEXT = `
 ### 🚀 High-Performance Markdown
@@ -100,6 +103,110 @@ type MarkdownRendererPanelProps = {
   hasContent: boolean;
 };
 
+type RawPreviewPanelProps = {
+  session: ReturnType<typeof useMarkdownSession>;
+};
+
+function getRawPreviewText(text: string): string {
+  if (text.length <= RAW_PREVIEW_MAX_CHARS) return text;
+  return text.slice(text.length - RAW_PREVIEW_MAX_CHARS);
+}
+
+function readSessionText(
+  session: ReturnType<typeof useMarkdownSession>,
+  fallback = "",
+): string {
+  try {
+    return session.getSession().getAllText();
+  } catch {
+    return fallback;
+  }
+}
+
+const RawPreviewPanel = memo(function RawPreviewPanel({
+  session,
+}: RawPreviewPanelProps) {
+  const rawScrollViewRef = useRef<ScrollView>(null);
+  const [rawText, setRawText] = useState(() =>
+    getRawPreviewText(readSessionText(session)),
+  );
+  const rawTextRef = useRef(rawText);
+
+  const getSessionText = useCallback(
+    (fallback: string) => {
+      return readSessionText(session, fallback);
+    },
+    [session],
+  );
+
+  const handleRawContentSizeChange = useCallback(() => {
+    rawScrollViewRef.current?.scrollToEnd({ animated: false });
+  }, []);
+
+  useEffect(() => {
+    rawTextRef.current = rawText;
+  }, [rawText]);
+
+  useEffect(() => {
+    const pendingRef = { current: false };
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const flush = () => {
+      timer = null;
+      if (!pendingRef.current) return;
+      pendingRef.current = false;
+
+      const nextText = getRawPreviewText(getSessionText(rawTextRef.current));
+      if (nextText !== rawTextRef.current) {
+        rawTextRef.current = nextText;
+        setRawText(nextText);
+      }
+    };
+
+    let unsubscribe: (() => void) | null = null;
+
+    try {
+      unsubscribe = session.getSession().addListener(() => {
+        pendingRef.current = true;
+        if (!timer) {
+          timer = setTimeout(flush, RAW_PREVIEW_SYNC_INTERVAL_MS);
+        }
+      });
+    } catch {
+      return () => {
+        if (timer) clearTimeout(timer);
+      };
+    }
+
+    return () => {
+      pendingRef.current = false;
+      unsubscribe?.();
+      if (timer) clearTimeout(timer);
+    };
+  }, [session, getSessionText]);
+
+  return (
+    <ExamplePanel style={styles.card}>
+      <ScrollView
+        ref={rawScrollViewRef}
+        style={styles.cardScroll}
+        nestedScrollEnabled
+        bounces={false}
+        alwaysBounceVertical={false}
+        overScrollMode="never"
+        contentContainerStyle={styles.scrollContent}
+        onContentSizeChange={handleRawContentSizeChange}
+      >
+        {rawText.length === 0 ? (
+          <Text style={styles.placeholderText}>Waiting for input...</Text>
+        ) : (
+          <Text style={styles.rawText}>{rawText}</Text>
+        )}
+      </ScrollView>
+    </ExamplePanel>
+  );
+});
+
 const MarkdownRendererPanel = memo(function MarkdownRendererPanel({
   session,
   hasContent,
@@ -148,23 +255,14 @@ export default function TokenStreamScreen() {
 
   const [isStreamMode, setIsStreamMode] = useState(false);
   const [streamOffset, setStreamOffset] = useState(0);
-  const [rawText, setRawText] = useState("");
+  const [hasStreamContent, setHasStreamContent] = useState(false);
+  const [isUiActive, setIsUiActive] = useState(true);
+  const [rawPreviewResetKey, setRawPreviewResetKey] = useState(0);
 
   const session = useMarkdownSession();
   const streamIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const streamOffsetRef = useRef(0);
-  const rawTextRef = useRef(rawText);
-
-  const getSessionText = useCallback(
-    (fallback: string) => {
-      try {
-        return session.getSession().getAllText();
-      } catch {
-        return fallback;
-      }
-    },
-    [session],
-  );
+  const hasStreamContentRef = useRef(false);
 
   const appendToSession = useCallback(
     (chunk: string) => {
@@ -185,14 +283,13 @@ export default function TokenStreamScreen() {
     }
     setIsStreamMode(false);
     setStreamOffset(streamOffsetRef.current);
-    const snapshotText = getSessionText(rawTextRef.current);
-    rawTextRef.current = snapshotText;
-    setRawText(snapshotText);
-  }, [getSessionText]);
+  }, []);
 
   const startStream = useCallback(() => {
     if (!isStreamMode && streamOffsetRef.current === 0) {
       session.clear();
+      hasStreamContentRef.current = false;
+      setHasStreamContent(false);
     }
 
     setIsStreamMode(true);
@@ -215,6 +312,10 @@ export default function TokenStreamScreen() {
         stopStream();
         return;
       }
+      if (!hasStreamContentRef.current) {
+        hasStreamContentRef.current = true;
+        setHasStreamContent(true);
+      }
       streamOffsetRef.current += chunk.length;
     }, TOKEN_DELAY_MS);
   }, [session, stopStream, isStreamMode, appendToSession]);
@@ -222,9 +323,10 @@ export default function TokenStreamScreen() {
   const clearStream = useCallback(() => {
     stopStream();
     streamOffsetRef.current = 0;
+    hasStreamContentRef.current = false;
     setStreamOffset(0);
-    setRawText("");
-    rawTextRef.current = "";
+    setHasStreamContent(false);
+    setRawPreviewResetKey((key) => key + 1);
     session.clear();
   }, [stopStream, session]);
 
@@ -234,54 +336,19 @@ export default function TokenStreamScreen() {
     };
   }, []);
 
-  const rawScrollViewRef = useRef<ScrollView>(null);
-  const handleRawContentSizeChange = useCallback(() => {
-    rawScrollViewRef.current?.scrollToEnd({ animated: false });
-  }, []);
-
-  useEffect(() => {
-    rawTextRef.current = rawText;
-  }, [rawText]);
-
-  useEffect(() => {
-    const pendingRef = { current: false };
-    let timer: ReturnType<typeof setTimeout> | null = null;
-
-    const flush = () => {
-      timer = null;
-      if (!pendingRef.current) return;
-      pendingRef.current = false;
-
-      const nextText = getSessionText(rawTextRef.current);
-      if (nextText !== rawTextRef.current) {
-        rawTextRef.current = nextText;
-        setRawText(nextText);
-      }
-      setStreamOffset(streamOffsetRef.current);
-
-    };
-
-    let unsubscribe: (() => void) | null = null;
-
-    try {
-      unsubscribe = session.getSession().addListener(() => {
-        pendingRef.current = true;
-        if (!timer) {
-          timer = setTimeout(flush, RAW_PREVIEW_SYNC_INTERVAL_MS);
-        }
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+      const task = InteractionManager.runAfterInteractions(() => {
+        if (!cancelled) setIsUiActive(true);
       });
-    } catch {
       return () => {
-        if (timer) clearTimeout(timer);
+        cancelled = true;
+        task.cancel();
+        setIsUiActive(false);
       };
-    }
-
-    return () => {
-      pendingRef.current = false;
-      unsubscribe?.();
-      if (timer) clearTimeout(timer);
-    };
-  }, [session, getSessionText]);
+    }, []),
+  );
 
   return (
     <ExampleScreen paddingBottom={0} style={styles.screenContent}>
@@ -338,30 +405,17 @@ export default function TokenStreamScreen() {
           </Text>
         </ExamplePanel>
         <ExampleSectionLabel>Raw Token Data</ExampleSectionLabel>
-        <ExamplePanel style={styles.card}>
-          <ScrollView
-            ref={rawScrollViewRef}
-            style={styles.cardScroll}
-            nestedScrollEnabled
-            bounces={false}
-            alwaysBounceVertical={false}
-            overScrollMode="never"
-            contentContainerStyle={styles.scrollContent}
-            onContentSizeChange={handleRawContentSizeChange}
-          >
-            {rawText.length === 0 ? (
-              <Text style={styles.placeholderText}>Waiting for input...</Text>
-            ) : (
-              <Text style={styles.rawText}>{rawText}</Text>
-            )}
-          </ScrollView>
-        </ExamplePanel>
+        {isUiActive ? (
+          <RawPreviewPanel key={rawPreviewResetKey} session={session} />
+        ) : null}
 
         <ExampleSectionLabel>Markdown Renderer</ExampleSectionLabel>
-        <MarkdownRendererPanel
-          session={session}
-          hasContent={rawText.length > 0}
-        />
+        {isUiActive ? (
+          <MarkdownRendererPanel
+            session={session}
+            hasContent={hasStreamContent}
+          />
+        ) : null}
       </ScrollView>
     </ExampleScreen>
   );

--- a/apps/example/app/render-stream.tsx
+++ b/apps/example/app/render-stream.tsx
@@ -107,6 +107,29 @@ export default function TokenStreamScreen() {
   const streamOffsetRef = useRef(0);
   const rawTextRef = useRef(rawText);
 
+  const getSessionText = useCallback(
+    (fallback: string) => {
+      try {
+        return session.getSession().getAllText();
+      } catch {
+        return fallback;
+      }
+    },
+    [session],
+  );
+
+  const appendToSession = useCallback(
+    (chunk: string) => {
+      try {
+        session.getSession().append(chunk);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [session],
+  );
+
   const stopStream = useCallback(() => {
     if (streamIntervalRef.current) {
       clearInterval(streamIntervalRef.current);
@@ -114,10 +137,10 @@ export default function TokenStreamScreen() {
     }
     setIsStreamMode(false);
     setStreamOffset(streamOffsetRef.current);
-    const snapshotText = session.getSession().getAllText();
+    const snapshotText = getSessionText(rawTextRef.current);
     rawTextRef.current = snapshotText;
     setRawText(snapshotText);
-  }, [session]);
+  }, [getSessionText]);
 
   const startStream = useCallback(() => {
     if (!isStreamMode && streamOffsetRef.current === 0) {
@@ -140,10 +163,13 @@ export default function TokenStreamScreen() {
         return;
       }
 
-      session.getSession().append(chunk);
+      if (!appendToSession(chunk)) {
+        stopStream();
+        return;
+      }
       streamOffsetRef.current += chunk.length;
     }, TOKEN_DELAY_MS);
-  }, [session, stopStream, isStreamMode]);
+  }, [session, stopStream, isStreamMode, appendToSession]);
 
   const clearStream = useCallback(() => {
     stopStream();
@@ -195,7 +221,7 @@ export default function TokenStreamScreen() {
       if (!pendingRef.current) return;
       pendingRef.current = false;
 
-      const nextText = session.getSession().getAllText();
+      const nextText = getSessionText(rawTextRef.current);
       if (nextText !== rawTextRef.current) {
         rawTextRef.current = nextText;
         setRawText(nextText);
@@ -207,18 +233,27 @@ export default function TokenStreamScreen() {
       }
     };
 
-    const unsubscribe = session.getSession().addListener(() => {
-      pendingRef.current = true;
-      if (!timer) {
-        timer = setTimeout(flush, RAW_PREVIEW_SYNC_INTERVAL_MS);
-      }
-    });
+    let unsubscribe: (() => void) | null = null;
+
+    try {
+      unsubscribe = session.getSession().addListener(() => {
+        pendingRef.current = true;
+        if (!timer) {
+          timer = setTimeout(flush, RAW_PREVIEW_SYNC_INTERVAL_MS);
+        }
+      });
+    } catch {
+      return () => {
+        if (timer) clearTimeout(timer);
+      };
+    }
 
     return () => {
-      unsubscribe();
+      pendingRef.current = false;
+      unsubscribe?.();
       if (timer) clearTimeout(timer);
     };
-  }, [session, isStreamMode, scheduleAutoScroll]);
+  }, [session, isStreamMode, scheduleAutoScroll, getSessionText]);
 
   return (
     <ExampleScreen paddingBottom={0} style={styles.screenContent}>
@@ -317,7 +352,7 @@ export default function TokenStreamScreen() {
               </View>
             ) : (
               <MarkdownStream
-                session={session.getSession()}
+                session={session}
                 updateStrategy="raf"
                 useTransitionUpdates
               />

--- a/apps/example/components/example-ui.tsx
+++ b/apps/example/components/example-ui.tsx
@@ -51,7 +51,9 @@ export function ExamplePanel({ children, style }: PanelProps) {
 type ActionButtonProps = {
   children: ReactNode;
   active?: boolean;
+  accessibilityLabel?: string;
   icon?: ReactNode;
+  testID?: string;
   tone?: "primary" | "danger" | "neutral";
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
@@ -60,13 +62,22 @@ type ActionButtonProps = {
 export function ExampleActionButton({
   children,
   active,
+  accessibilityLabel,
   icon,
+  testID,
   tone = "primary",
   style,
   onPress,
 }: ActionButtonProps) {
+  const label =
+    accessibilityLabel ?? (typeof children === "string" ? children : undefined);
+
   return (
     <Pressable
+      accessibilityLabel={label}
+      accessibilityRole="button"
+      accessibilityState={active ? { selected: true } : undefined}
+      testID={testID}
       style={[
         styles.button,
         tone === "primary" && styles.primaryButton,

--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
     },
     "packages/react-native-nitro-markdown": {
       "name": "react-native-nitro-markdown",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.0.0",
         "@types/react": "~19.2.15",

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-markdown",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "High-performance Markdown parser for React Native using Nitro Modules and md4c",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-markdown/src/MarkdownContext.ts
+++ b/packages/react-native-nitro-markdown/src/MarkdownContext.ts
@@ -123,6 +123,8 @@ export type CustomRenderers = Partial<{
   >;
 }>;
 
+export type MarkdownRenderers = CustomRenderers;
+
 export type TableOptions = {
   minColumnWidth?: number;
   measurementStabilizeMs?: number;

--- a/packages/react-native-nitro-markdown/src/__tests__/incremental-ast.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/incremental-ast.test.ts
@@ -1,6 +1,10 @@
 import { mockParser } from "./setup";
 import type { MarkdownNode } from "../headless";
-import { getNextStreamAst, parseMarkdownAst } from "../utils/incremental-ast";
+import {
+  getNextStreamAst,
+  parseMarkdownAst,
+  reuseStableAstNodes,
+} from "../utils/incremental-ast";
 import { getTextContent } from "../headless";
 
 const setTrailingPathEnd = (ast: MarkdownNode, end: number): MarkdownNode => {
@@ -79,6 +83,75 @@ describe("incremental AST", () => {
     });
 
     expect(mockParser.parse).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses stable nodes after a full parse fallback", () => {
+    const stableParagraph: MarkdownNode = {
+      type: "paragraph",
+      children: [{ type: "text", content: "Stable" }],
+    };
+    const previousAst: MarkdownNode = {
+      type: "document",
+      beg: 0,
+      end: 15,
+      children: [
+        stableParagraph,
+        {
+          type: "paragraph",
+          children: [{ type: "text", content: "Before" }],
+        },
+      ],
+    };
+
+    const nextAst = getNextStreamAst({
+      previousAst,
+      previousText: "Stable\n\nBefore\n",
+      nextText: "Stable\n\nBefore\nAfter",
+    });
+
+    expect(mockParser.parse).toHaveBeenCalledTimes(1);
+    expect(nextAst).not.toBe(previousAst);
+    expect(nextAst.children?.[0]).toBe(stableParagraph);
+  });
+
+  it("keeps changed nodes from the parsed AST", () => {
+    const previousStableChild: MarkdownNode = {
+      type: "paragraph",
+      children: [{ type: "text", content: "Stable" }],
+    };
+    const previousAst: MarkdownNode = {
+      type: "document",
+      children: [
+        previousStableChild,
+        {
+          type: "paragraph",
+          children: [{ type: "text", content: "Before" }],
+        },
+      ],
+    };
+    const nextChangedChild: MarkdownNode = {
+      type: "paragraph",
+      children: [{ type: "text", content: "After" }],
+    };
+    const nextAst: MarkdownNode = {
+      type: "document",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", content: "Stable" }],
+        },
+        nextChangedChild,
+      ],
+    };
+
+    const result = reuseStableAstNodes(previousAst, nextAst);
+
+    expect(result).not.toBe(previousAst);
+    expect(result.children?.[0]).toBe(previousStableChild);
+    expect(result.children?.[1]).not.toBe(previousAst.children?.[1]);
+    expect(result.children?.[1]?.children?.[0]).toBe(
+      nextChangedChild.children?.[0],
+    );
   });
 
   it("falls back to full parse when incremental disabled", () => {

--- a/packages/react-native-nitro-markdown/src/__tests__/markdown-pipeline.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/markdown-pipeline.test.ts
@@ -167,4 +167,82 @@ describe("Markdown plugin pipeline", () => {
       consoleErrorSpy.mockRestore();
     }
   });
+
+  it("preserves unchanged sourceAst child identity between renders", () => {
+    const firstParagraph: MarkdownNode = {
+      type: "paragraph",
+      children: [{ type: "text", content: "stable paragraph" }],
+    };
+    const secondParagraph: MarkdownNode = {
+      type: "paragraph",
+      children: [{ type: "text", content: "first version" }],
+    };
+    const nextSecondParagraph: MarkdownNode = {
+      type: "paragraph",
+      children: [{ type: "text", content: "second version" }],
+    };
+    const renderParagraph = jest.fn(({ node }: { node: MarkdownNode }) =>
+      createElement("Text", null, node.children?.[0]?.content ?? ""),
+    );
+    const renderers = {
+      paragraph: renderParagraph,
+    };
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation((message?: unknown, ...args: unknown[]) => {
+        if (
+          typeof message === "string" &&
+          message.includes("react-test-renderer is deprecated")
+        ) {
+          return;
+        }
+        process.stderr.write(
+          [message, ...args].map((arg) => String(arg)).join(" ") + "\n",
+        );
+      });
+    let renderer: ReactTestRenderer | undefined;
+
+    try {
+      act(() => {
+        renderer = create(
+          createElement(
+            Markdown,
+            {
+              sourceAst: {
+                type: "document",
+                children: [firstParagraph, secondParagraph],
+              },
+              renderers,
+            },
+            "ignored markdown",
+          ),
+        );
+      });
+
+      act(() => {
+        renderer!.update(
+          createElement(
+            Markdown,
+            {
+              sourceAst: {
+                type: "document",
+                children: [firstParagraph, nextSecondParagraph],
+              },
+              renderers,
+            },
+            "ignored markdown",
+          ),
+        );
+      });
+
+      const renderedTexts = renderParagraph.mock.calls.map(
+        ([props]) => props.node.children?.[0]?.content,
+      );
+      expect(renderedTexts.filter((text) => text === "stable paragraph")).toHaveLength(1);
+      expect(renderedTexts.filter((text) => text === "first version")).toHaveLength(1);
+      expect(renderedTexts.filter((text) => text === "second version")).toHaveLength(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react-native-nitro-markdown/src/__tests__/markdown-stream.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/markdown-stream.test.ts
@@ -126,6 +126,38 @@ describe("MarkdownStream", () => {
     );
   });
 
+  it("keeps the stream subscription stable when parser option values do not change", () => {
+    const session = createSession({
+      allText: "hello",
+      rangeText: " world",
+    });
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(MarkdownStream, {
+          session,
+          options: { gfm: true, math: true },
+          updateIntervalMs: 1,
+        }),
+      );
+    });
+
+    expect(session.addListener).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      renderer!.update(
+        React.createElement(MarkdownStream, {
+          session,
+          options: { gfm: true, math: true },
+          updateIntervalMs: 1,
+        }),
+      );
+    });
+
+    expect(session.addListener).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to full session text when reset-like range reads fail", () => {
     const session = createSession({
       allText: "old",

--- a/packages/react-native-nitro-markdown/src/__tests__/markdown-stream.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/markdown-stream.test.ts
@@ -221,4 +221,39 @@ describe("MarkdownStream", () => {
     }).not.toThrow();
     expect(unsubscribe).toHaveBeenCalled();
   });
+
+  it("does not throw when a pending flush reads a disposed session", () => {
+    const session = createSession({
+      allText: "hello",
+      rangeText: " world",
+    });
+
+    act(() => {
+      TestRenderer.create(
+        React.createElement(MarkdownStream, {
+          session,
+          updateIntervalMs: 1,
+        }),
+      );
+    });
+
+    act(() => {
+      session.setAllText("hello world");
+      session.emit(5, 11);
+      session.getTextRange = jest.fn(() => {
+        throw new Error("NativeState is null");
+      });
+      session.getAllText = jest.fn(() => {
+        throw new Error("NativeState is null");
+      });
+
+      expect(() => {
+        jest.runOnlyPendingTimers();
+      }).not.toThrow();
+    });
+
+    expect(markdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ children: "hello" }),
+    );
+  });
 });

--- a/packages/react-native-nitro-markdown/src/__tests__/session.test.ts
+++ b/packages/react-native-nitro-markdown/src/__tests__/session.test.ts
@@ -74,7 +74,7 @@ describe("createMarkdownSession", () => {
     expect(session.getAllText()).toBe("hello");
   });
 
-  it("disposes hook-owned sessions on unmount", () => {
+  it("disposes hook-owned sessions on unmount without emitting clear updates", () => {
     createHybridObjectMock.mockClear();
 
     let renderer: TestRenderer.ReactTestRenderer | null = null;
@@ -88,7 +88,7 @@ describe("createMarkdownSession", () => {
       renderer!.unmount();
     });
 
-    expect(session.clear).toHaveBeenCalled();
+    expect(session.clear).not.toHaveBeenCalled();
     expect(session.dispose).toHaveBeenCalled();
   });
 

--- a/packages/react-native-nitro-markdown/src/index.ts
+++ b/packages/react-native-nitro-markdown/src/index.ts
@@ -48,6 +48,7 @@ export type {
   LinkPressHandler,
   MarkdownContextValue,
   CustomRendererPropsByNode,
+  MarkdownRenderers,
   TableOptions,
 } from "./MarkdownContext";
 

--- a/packages/react-native-nitro-markdown/src/markdown-stream.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown-stream.tsx
@@ -3,10 +3,12 @@ import {
   useEffect,
   useRef,
   useCallback,
+  useMemo,
   startTransition,
   type FC,
 } from "react";
 import type { MarkdownNode } from "./headless";
+import type { ParserOptions } from "./Markdown.nitro";
 import { Markdown, type MarkdownProps } from "./markdown";
 import type { MarkdownSession } from "./specs/MarkdownSession.nitro";
 import {
@@ -19,6 +21,22 @@ const normalizeOffset = (value: number): number | null => {
   if (!Number.isFinite(value)) return null;
   if (value <= 0) return 0;
   return Math.floor(value);
+};
+
+const normalizeParserOptions = (
+  options?: ParserOptions,
+): ParserOptions | undefined => {
+  if (!options) return undefined;
+
+  const gfm = options.gfm;
+  const math = options.math;
+  const html = options.html;
+
+  if (gfm === undefined && math === undefined && html === undefined) {
+    return undefined;
+  }
+
+  return { gfm, math, html };
 };
 
 const resolveStreamText = ({
@@ -115,9 +133,21 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
   ...props
 }) => {
   const activeSession = resolveMarkdownSession(session);
+  const parserOptionGfm = options?.gfm;
+  const parserOptionMath = options?.math;
+  const parserOptionHtml = options?.html;
+  const parserOptions = useMemo(
+    () =>
+      normalizeParserOptions({
+        gfm: parserOptionGfm,
+        math: parserOptionMath,
+        html: parserOptionHtml,
+      }),
+    [parserOptionGfm, parserOptionMath, parserOptionHtml],
+  );
   const parseText = useCallback(
-    (text: string): MarkdownNode => parseMarkdownAst(text, options),
-    [options],
+    (text: string): MarkdownNode => parseMarkdownAst(text, parserOptions),
+    [parserOptions],
   );
   const createEmptyAst = (): MarkdownNode => ({
     type: "document",
@@ -204,7 +234,7 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
         : getNextStreamAst({
             allowIncremental,
             nextText: latest,
-            options,
+            options: parserOptions,
             previousAst: previousState.ast,
             previousText: previousState.text,
           });
@@ -291,8 +321,7 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
   }, [
     allowIncremental,
     hasBeforeParsePlugins,
-    options,
-    plugins,
+    parserOptions,
     activeSession,
     updateIntervalMs,
     updateStrategy,

--- a/packages/react-native-nitro-markdown/src/markdown-stream.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown-stream.tsx
@@ -184,13 +184,19 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
       pendingToRef.current = null;
       forceFullSyncRef.current = false;
 
-      const latest = resolveStreamText({
-        forceFullSync,
-        pendingFrom,
-        pendingTo,
-        previousText: previousState.text,
-        session: activeSession,
-      });
+      let latest: string;
+      try {
+        latest = resolveStreamText({
+          forceFullSync,
+          pendingFrom,
+          pendingTo,
+          previousText: previousState.text,
+          session: activeSession,
+        });
+      } catch (error) {
+        warnStreamError("[NitroMarkdown] Failed to read stream session:", error);
+        return;
+      }
       if (latest === previousState.text) return;
 
       const nextAst = hasBeforeParsePlugins
@@ -236,6 +242,8 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
 
     try {
       unsubscribe = activeSession.addListener((from, to) => {
+        if (!mountedRef.current) return;
+
         const nextFrom = normalizeOffset(from);
         const nextTo = normalizeOffset(to);
 
@@ -259,6 +267,10 @@ export const MarkdownStream: FC<MarkdownStreamProps> = ({
     }
 
     return () => {
+      pendingUpdateRef.current = false;
+      pendingFromRef.current = null;
+      pendingToRef.current = null;
+      forceFullSyncRef.current = false;
       try {
         unsubscribe?.();
       } catch (error) {

--- a/packages/react-native-nitro-markdown/src/markdown.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown.tsx
@@ -483,8 +483,14 @@ export const Markdown: FC<MarkdownProps> = ({
         math: parserOptionMath,
         html: parserOptionHtml,
       });
+      const shouldCloneSourceAst =
+        sourceAst &&
+        (Boolean(astTransform) ||
+          sortedPlugins?.some((plugin) => plugin.afterParse) === true);
       let parsedAst = sourceAst
-        ? cloneMarkdownNode(sourceAst)
+        ? shouldCloneSourceAst
+          ? cloneMarkdownNode(sourceAst)
+          : sourceAst
         : parseCache
           ? getCachedParsedAst(markdownToParse, parserOptions)
           : parseWithNativeParser(markdownToParse, parserOptions);

--- a/packages/react-native-nitro-markdown/src/renderers/image.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/image.tsx
@@ -2,6 +2,7 @@ import {
   useState,
   useEffect,
   useMemo,
+  useRef,
   type ReactNode,
   type FC,
   type ComponentType,
@@ -47,6 +48,7 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [aspectRatio, setAspectRatio] = useState<number | undefined>(undefined);
+  const mountedRef = useRef(true);
   const { theme, imageOptions } = useMarkdownContext();
   const allowedImageHref = useMemo(
     () => getAllowedImageHref(url, imageOptions),
@@ -114,6 +116,13 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
       }),
     [theme, aspectRatio],
   );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     let isMounted = true;
@@ -236,9 +245,11 @@ export const Image: FC<ImageProps> = ({ url, title, alt, Renderer, style }) => {
         accessibilityRole={accessibilityLabel ? "image" : undefined}
         accessibilityLabel={accessibilityLabel}
         onLoad={() => {
+          if (!mountedRef.current) return;
           setLoading(false);
         }}
         onError={() => {
+          if (!mountedRef.current) return;
           setLoading(false);
           setError(true);
         }}

--- a/packages/react-native-nitro-markdown/src/renderers/math.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/math.tsx
@@ -247,6 +247,14 @@ export const MathInline: FC<MathInlineProps> = ({ content, style }) => {
   const { theme } = useMarkdownContext();
   const styles = getCachedStyles(mathStylesCache, theme, createMathStyles);
   const [hasRenderError, setHasRenderError] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   if (!content) return null;
 
@@ -260,6 +268,7 @@ export const MathInline: FC<MathInlineProps> = ({ content, style }) => {
           color={theme.colors.text}
           style={styles.ratexInline}
           onError={() => {
+            if (!mountedRef.current) return;
             setHasRenderError(true);
           }}
         />
@@ -283,6 +292,14 @@ export const MathBlock: FC<MathBlockProps> = ({ content, style }) => {
   const { theme } = useMarkdownContext();
   const styles = getCachedStyles(mathStylesCache, theme, createMathStyles);
   const [hasRenderError, setHasRenderError] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   if (!content) return null;
 
@@ -300,6 +317,7 @@ export const MathBlock: FC<MathBlockProps> = ({ content, style }) => {
             color={theme.colors.text}
             style={styles.ratexBlock}
             onError={() => {
+              if (!mountedRef.current) return;
               setHasRenderError(true);
             }}
           />

--- a/packages/react-native-nitro-markdown/src/use-markdown-stream.ts
+++ b/packages/react-native-nitro-markdown/src/use-markdown-stream.ts
@@ -21,13 +21,9 @@ export function useMarkdownSession(initialText?: string) {
     const session = sessionRef.current!;
     return () => {
       try {
-        session.clear();
+        session.dispose();
       } finally {
-        try {
-          session.dispose();
-        } finally {
-          sessionRef.current = null;
-        }
+        sessionRef.current = null;
       }
     };
   }, []);

--- a/packages/react-native-nitro-markdown/src/utils/incremental-ast.ts
+++ b/packages/react-native-nitro-markdown/src/utils/incremental-ast.ts
@@ -152,6 +152,83 @@ const endsAtBlockBoundary = (text: string): boolean => {
   return text.endsWith("\n") || text.endsWith("\r");
 };
 
+const nodesHaveMatchingMetadata = (
+  previousNode: MarkdownNode,
+  nextNode: MarkdownNode,
+): boolean => {
+  return (
+    previousNode.type === nextNode.type &&
+    previousNode.content === nextNode.content &&
+    previousNode.level === nextNode.level &&
+    previousNode.href === nextNode.href &&
+    previousNode.title === nextNode.title &&
+    previousNode.alt === nextNode.alt &&
+    previousNode.language === nextNode.language &&
+    previousNode.ordered === nextNode.ordered &&
+    previousNode.start === nextNode.start &&
+    previousNode.checked === nextNode.checked &&
+    previousNode.isHeader === nextNode.isHeader &&
+    previousNode.align === nextNode.align &&
+    previousNode.beg === nextNode.beg &&
+    previousNode.end === nextNode.end
+  );
+};
+
+export const reuseStableAstNodes = (
+  previousNode: MarkdownNode,
+  nextNode: MarkdownNode,
+): MarkdownNode => {
+  if (previousNode.type !== nextNode.type) {
+    return nextNode;
+  }
+
+  const hasMatchingMetadata = nodesHaveMatchingMetadata(previousNode, nextNode);
+  const previousChildren = previousNode.children;
+  const nextChildren = nextNode.children;
+
+  if (!previousChildren || !nextChildren) {
+    return hasMatchingMetadata && previousChildren === nextChildren
+      ? previousNode
+      : nextNode;
+  }
+
+  if (previousChildren.length !== nextChildren.length) {
+    return {
+      ...nextNode,
+      children: nextChildren.map((nextChild, index) => {
+        const previousChild = previousChildren[index];
+        return previousChild
+          ? reuseStableAstNodes(previousChild, nextChild)
+          : nextChild;
+      }),
+    };
+  }
+
+  let hasChildChange = false;
+  const children = nextChildren.map((nextChild, index) => {
+    const child = reuseStableAstNodes(previousChildren[index], nextChild);
+    hasChildChange ||= child !== previousChildren[index];
+    return child;
+  });
+
+  if (hasMatchingMetadata && !hasChildChange) {
+    return previousNode;
+  }
+
+  return {
+    ...nextNode,
+    children,
+  };
+};
+
+const parseAstWithStableNodes = (
+  previousAst: MarkdownNode,
+  text: string,
+  options?: ParserOptions,
+): MarkdownNode => {
+  return reuseStableAstNodes(previousAst, parseAst(text, options));
+};
+
 export type IncrementalAstInput = {
   allowIncremental?: boolean;
   nextText: string;
@@ -168,7 +245,7 @@ export const getNextStreamAst = ({
   previousText,
 }: IncrementalAstInput): MarkdownNode => {
   if (!allowIncremental || !nextText.startsWith(previousText)) {
-    return parseAst(nextText, options);
+    return parseAstWithStableNodes(previousAst, nextText, options);
   }
 
   const appendedChunk = nextText.slice(previousText.length);
@@ -194,7 +271,7 @@ export const getNextStreamAst = ({
 
   if (!PLAIN_TEXT_APPEND_PATTERN.test(appendedChunk)) {
     if (endsAtBlockBoundary(previousText)) {
-      return parseAst(nextText, options);
+      return parseAstWithStableNodes(previousAst, nextText, options);
     }
 
     const textAppendedAst = appendPlainTextToAst(
@@ -208,12 +285,12 @@ export const getNextStreamAst = ({
   }
 
   if (insideFencedCodeBlock) {
-    return parseAst(nextText, options);
+    return parseAstWithStableNodes(previousAst, nextText, options);
   }
 
   // Correctness-first fallback: full reparse for all non-trivial appends.
   // Incremental append is only used for plain text chunks at the true trailing leaf.
-  return parseAst(nextText, options);
+  return parseAstWithStableNodes(previousAst, nextText, options);
 };
 
 export const parseMarkdownAst = (


### PR DESCRIPTION
# Summary
Fixes #55 by hardening MarkdownStream session disposal and update paths, reducing stream rerenders, keeping token streams smooth across tab navigation, and preparing react-native-nitro-markdown 0.7.2.

# Changes
- Guard stream flush/subscription behavior against disposed sessions while preserving stable AST node reuse and parser option identity by value
- Add the exported MarkdownRenderers type alias and regression coverage for stable stream subscriptions
- Split the example stream renderer panel so raw token preview updates do not parent-render the markdown subtree; physical-device profiling reduced the 30s stream window from 72 commits and 22 MarkdownStream renders to 5 commits and 3 MarkdownStream renders
- Keep the example stream session alive across tab switches while freezing inactive tabs, detaching raw/markdown render work until focus returns, capping raw preview memory, and exposing action buttons for reliable profiling
- Sync README usage docs, CHANGELOG, package version, lockfile metadata, and npm publish workflow default tag for the 0.7.2 fix release
