### PR TITLE
Markdown 0.10.1: document Markdown onError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Breaking changes are always listed first in each release section** so upgrades
 stay safe.
 
+## [0.10.1] - 2026-08-13
+
+### Changes
+
+- **Breaking changes:** None.
+- Quick start now shows `<Markdown onError>` for native parse failures.
+  Headless `parseMarkdown` still throws. App theming stays in a local wrapper.
+
 ## [0.10.0] - 2026-08-12
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -66,12 +66,21 @@ import { Markdown } from "react-native-nitro-markdown";
 
 export function Article() {
   return (
-    <Markdown options={{ gfm: true, math: true }}>
+    <Markdown
+      options={{ gfm: true, math: true }}
+      onError={(error) => {
+        console.error(error);
+      }}
+    >
       {"# Hello\nThis is **native** markdown."}
     </Markdown>
   );
 }
 ```
+
+Native parse failures call `onError` instead of rendering an empty document.
+Headless `parseMarkdown` throws; do not treat an empty AST as success. Keep
+product fonts and colors in an app wrapper around `<Markdown>`.
 
 ## Streaming (LLM / chat)
 

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-markdown",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Fast native Markdown parser and renderer for React Native — CommonMark + GFM, streaming, headless AST, and math, powered by Nitro Modules and md4c",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
# Summary

Show `<Markdown onError>` in the quick start. Headless `parseMarkdown` still throws; theming stays in an app wrapper.

# Changes

- Document native parse failures via `onError` and that an empty AST is not success for headless parse.
- Bump to 0.10.1. Breaking changes: none.