### PR TITLE
Fix Markdown release runner

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   publish:
     name: Publish react-native-nitro-markdown to npm
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     permissions:
       contents: read
       id-token: write
@@ -48,10 +48,11 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Install C++ coverage tools
+      - name: Verify C++ coverage tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang llvm
+          clang --version
+          llvm-cov --version
+          llvm-profdata --version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
# Changes

- Run the Markdown release preflight on macos-26, where the iOS toolchain and CocoaPods are available.
- Verify the preinstalled Clang and LLVM coverage tools instead of using Ubuntu-only apt commands.
- Keep release-tag validation, manual dry-run dispatch, and trusted npm publishing behavior unchanged.