### PR TITLE
Make Markdown release preflight tag-safe

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -84,7 +84,10 @@ jobs:
           NODE
 
       - name: Release preflight
-        run: bun run release:preflight
+        run: |
+          bun run check:ci
+          bun run example:check
+          bun run publish-package:dry-run
 
       - name: Select npm dist tag
         run: |


### PR DESCRIPTION
# Changes

- Run tag-safe Markdown release checks directly so immutable release tags cannot invoke native Android or iOS builds.
- Preserve package, example configuration, and dry-run publish validation before manual recovery.