### PR TITLE
Fix Markdown parser frame initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@
 [![Nitro Modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.37.0%20%3C0.38.0-black)](https://nitro.margelo.com/)
 [![TypeScript](https://img.shields.io/badge/typescript-6.0-3178c6)](https://www.typescriptlang.org/)
 
-**The fast Markdown engine for React Native.** Native **C++ parsing** (CommonMark
-
-- GitHub Flavored Markdown), real React Native rendering, first-class
-  **streaming** for LLM/chat output, and a **headless AST** API — powered by
-  [md4c](https://github.com/mity/md4c) and [Nitro Modules](https://nitro.margelo.com/).
+**A native Markdown engine for React Native.** Native **C++ parsing** for
+CommonMark and GitHub Flavored Markdown, real React Native rendering, first-class
+**streaming** for LLM/chat output, and a **headless AST** API — powered by
+[md4c](https://github.com/mity/md4c) and [Nitro Modules](https://nitro.margelo.com/).
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/JoaoPauloCMarra/react-native-nitro-markdown/main/readme/render.png" alt="Nitro Markdown rendering rich GitHub Flavored Markdown natively in React Native" width="250" />
@@ -30,9 +29,10 @@
 
 Most React Native Markdown libraries parse in JavaScript on the JS thread. Nitro
 Markdown parses in a **native C++ engine** over JSI, then renders flexible React
-Native components — so you get native parse speed _and_ component flexibility.
+Native components — giving you a native parser boundary with component flexibility.
 
-- ⚡ **Native C++ parsing** — ~2.8× to ~19× faster than JS parsers ([benchmarks](https://github.com/JoaoPauloCMarra/react-native-nitro-markdown/blob/main/docs/comparison.md)).
+- ⚡ **Native C++ parsing** — CommonMark + GFM with a benchmark harness so you
+  can measure parsing and rendering on your target device ([benchmarks](https://github.com/JoaoPauloCMarra/react-native-nitro-markdown/blob/main/docs/comparison.md)).
 - 🔀 **Streaming** — built for token-by-token LLM / chat output.
 - 🧩 **Headless AST** — parse without UI for search, validation, indexing.
 - 🎨 **Real components** — theme, override per node, or swap whole renderers.
@@ -149,7 +149,7 @@ const ast = parseMarkdown("# Title");
 const mathAst = parseMarkdownWithOptions("Inline $x^2$", { math: true });
 const text = extractPlainText("Hello **world**"); // "Hello world"
 
-// Search / indexing: skip source offsets natively for a leaner, faster AST.
+// Search / indexing: skip source offsets natively for a leaner AST.
 const lean = parseMarkdownWithOptions(doc, { sourceOffsets: false });
 ```
 
@@ -227,17 +227,20 @@ See **[Usage](https://github.com/JoaoPauloCMarra/react-native-nitro-markdown/blo
 
 ## Performance
 
-Parsing a ~320 KB document (example app, iOS Simulator; ratios are stable):
+Representative development-build measurement for a ~320 KB document on the
+iPhone 17 iOS Simulator (absolute values vary by device, build, and workload):
 
-| Parser           | Time       | vs Nitro |
-| ---------------- | ---------- | -------- |
-| **Nitro (C++)**  | **~41 ms** | —        |
-| CommonMark (JS)  | ~113 ms    | ~2.8×    |
-| Markdown-It (JS) | ~184 ms    | ~4.5×    |
-| Marked (JS)      | ~814 ms    | ~19.8×   |
+| Parser           | Time   |
+| ---------------- | ------ |
+| **Nitro (C++)**  | ~242 ms |
+| CommonMark (JS)  | ~117 ms |
+| Markdown-It (JS) | ~191 ms |
+| Marked (JS)      | ~1,036 ms |
 
-Reproduce it: run the example app and tap **Run Benchmark**. Methodology and a
-full capability matrix: **[Comparison & benchmarks](https://github.com/JoaoPauloCMarra/react-native-nitro-markdown/blob/main/docs/comparison.md)**.
+These are development-build measurements, not a release-performance guarantee.
+Reproduce them on your target device by running the example app and tapping
+**Run Benchmark**. Methodology and a full capability matrix:
+**[Comparison & benchmarks](https://github.com/JoaoPauloCMarra/react-native-nitro-markdown/blob/main/docs/comparison.md)**.
 
 ## Security
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -5,10 +5,11 @@
 Most React Native Markdown libraries parse in **JavaScript** (markdown-it,
 marked, commonmark) and render React components. Nitro Markdown moves parsing
 into a **native C++ engine** (md4c, vendored as `nitromd`) over JSI, then renders
-flexible React Native components on top. You get the parse speed of native with
+flexible React Native components on top. You get a native parser boundary with
 the flexibility of components — plus first-class streaming and headless APIs.
 
-- ⚡ **Native C++ parsing** — CommonMark + GFM, multiple times faster than JS parsers.
+- ⚡ **Native C++ parsing** — CommonMark + GFM with a reproducible benchmark
+  harness; measure on the device and build configuration you ship.
 - 🔀 **Streaming** — purpose-built for token-by-token LLM / chat output ([streaming](./streaming.md)).
 - 🧩 **Headless AST** — parse without rendering, for search/validation/indexing ([headless](./headless.md)).
 - 🎨 **Real components** — theme, override per node, or swap whole renderers ([customization](./customization.md)).
@@ -18,19 +19,21 @@ the flexibility of components — plus first-class streaming and headless APIs.
 ## Parse benchmark
 
 Parsing the same ~320 KB Markdown document, measured in the example app's
-**Bench** tab on an iOS Simulator (median of repeated runs; absolute numbers vary
-by device, the ratios are stable):
+**Bench** tab on the iPhone 17 iOS Simulator in a development build. Absolute
+numbers vary by device, build, and workload; use the example benchmark for a
+release decision.
 
-| Parser           | Time       | vs Nitro      |
-| ---------------- | ---------- | ------------- |
-| **Nitro (C++)**  | **~41 ms** | —             |
-| CommonMark (JS)  | ~113 ms    | ~2.8× slower  |
-| Markdown-It (JS) | ~184 ms    | ~4.5× slower  |
-| Marked (JS)      | ~814 ms    | ~19.8× slower |
+| Parser           | Time   |
+| ---------------- | ------ |
+| **Nitro (C++)**  | ~242 ms |
+| CommonMark (JS)  | ~117 ms |
+| Markdown-It (JS) | ~191 ms |
+| Marked (JS)      | ~1,036 ms |
 
-Math rendering (via `ratex-react-native`) is ~10× faster than legacy MathJax/SVG
-(~233 ms vs ~2517 ms in the same run). Reproduce any of this yourself: run the
-example app and tap **Run Benchmark**.
+Math rendering via `ratex-react-native` measured ~350 ms versus ~1,216 ms for
+legacy MathJax/SVG in the same development run. These measurements are not a
+promise of release performance. Reproduce them on your target device by running
+the example app and tapping **Run Benchmark**.
 
 ## Capability matrix
 

--- a/packages/react-native-nitro-markdown/cpp/bindings/HybridMarkdownParser.cpp
+++ b/packages/react-native-nitro-markdown/cpp/bindings/HybridMarkdownParser.cpp
@@ -444,7 +444,9 @@ void appendNodeJson(
     const uint32_t utf16Length = byteIndex.utf16Length();
 
     std::vector<Frame> frames;
-    frames.push_back({root});
+    Frame rootFrame{};
+    rootFrame.node = root;
+    frames.push_back(std::move(rootFrame));
     size_t nodeCount = 0;
     size_t childSlotCount = 0;
     size_t workCount = 0;
@@ -526,7 +528,9 @@ void appendNodeJson(
                 continue;
             }
 
-            frames.push_back({std::move(child)});
+            Frame nestedFrame{};
+            nestedFrame.node = std::move(child);
+            frames.push_back(std::move(nestedFrame));
             continue;
         }
 


### PR DESCRIPTION
# Changes

- Initialize Markdown parser frames with value semantics so optional metadata and scalar traversal state are deterministic.
- Correct README and benchmark documentation to reflect current platform support and measured development-build results without unsupported performance claims.