### PR TITLE
docs: finalize v0.12.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Breaking changes are always listed first in each release section** so upgrades
 stay safe.
 
-## [0.12.0] - 2026-08-24
+## [0.12.0] - 2026-08-25
 
 ### Breaking changes
 
@@ -62,6 +62,10 @@ stay safe.
 
 ### Fixed
 
+- Native AST serialization initializes every traversal frame explicitly,
+  preventing undefined frame state while walking nested parser output.
+- Text style overrides now remain applied to inline text rendered beside inline
+  math without changing custom renderer behavior.
 - Markdown JSON serialization now counts actual emitted bytes against the
   64 MiB cap, so valid near-limit output is accepted without estimate-based
   false rejections.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -79,8 +79,8 @@ Nitro Markdown renders real components, so its render cost scales with the
 document. The default string path keeps the native AST internal, plain inline
 runs collapse to fewer native `Text` nodes, and long documents virtualize so
 only the visible screen mounts. On the same development fixtures,
-mount-to-layout measured 233.56 ms for the rich iOS document, 150.63 ms for its
-virtualized first screen, 262.29 ms for rich Android, and 164.96 ms for its
+mount-to-layout measured 217.24 ms for the rich iOS document, 150.50 ms for its
+virtualized first screen, 291.20 ms for rich Android, and 168.69 ms for its
 virtualized first screen. These are target and workload measurements, not
 release-performance guarantees. The example **Bench** tab tracks Nitro's
 render and first-screen times directly.


### PR DESCRIPTION
# Changes

- Finalize the 0.12.0 changelog with the publication date and complete breaking-change guidance.
- Record the final renderer fixes and synchronize comparison documentation with measured release evidence.