### PR TITLE
Fix jumping while scrolling virtualized markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Breaking changes are always listed first in each release section** so upgrades
 stay safe.
 
+## [0.12.3] - 2026-09-08
+
+### Breaking changes
+
+None.
+
+### Fixed
+
+- Virtualized documents preserve the visible scroll position while recycled
+  image and table rows finish laying out.
+
 ## [0.12.2] - 2026-09-08
 
 ### Breaking changes

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,6 +89,8 @@ screen mounts. This keeps time-to-first-screen and memory bounded:
 ```
 
 Use `virtualize` when `<Markdown>` is the primary scroll container on screen.
+Virtualized lists preserve the visible content position when rows change
+height, including images and tables that finish layout after mounting.
 
 ## Source AST rendering
 

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-markdown",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Fast native Markdown parser and renderer for React Native \u2014 CommonMark + GFM, streaming, headless AST, and math, powered by Nitro Modules and md4c",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-markdown/src/markdown.tsx
+++ b/packages/react-native-nitro-markdown/src/markdown.tsx
@@ -566,6 +566,7 @@ export const Markdown: FC<MarkdownProps> = ({
             renderItem={renderVirtualizedItem}
             keyExtractor={keyExtractor}
             style={baseStyles.virtualizedList}
+            maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
             initialNumToRender={virtualization?.initialNumToRender ?? 12}
             maxToRenderPerBatch={virtualization?.maxToRenderPerBatch ?? 12}
             windowSize={virtualization?.windowSize ?? 10}


### PR DESCRIPTION
# Summary
Fix visible jumps when scrolling back through virtualized markdown.

# Changes
- Keep the visible content anchored while recycled image and table rows finish laying out.
- Document the behavior and prepare 0.12.3.

Before the fix, a heading moved 192 points with the scroll offset unchanged. Recorded comparisons show it staying in place after the fix on the iOS simulator, physical iPhone and Android emulator.

Release preflight passed: 317 JS tests, 3,556 C++ checks, coverage, Expo checks and publish dry run. The Default and Custom demo screens were checked while scrolling down and back up.
