### PR TITLE
fix: prevent streamed list item content from collapsing

### DIFF
--- a/packages/react-native-nitro-markdown/src/renderers/list.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/list.tsx
@@ -126,7 +126,7 @@ const createListItemStyles = (theme: MarkdownTheme) =>
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
     listItemContent: {
-      flex: 1,
+      flexShrink: 1,
       minWidth: 0,
     },
   });
@@ -161,7 +161,7 @@ const createTaskListItemStyles = (theme: MarkdownTheme) =>
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
     taskContent: {
-      flex: 1,
+      flexShrink: 1,
       minWidth: 0,
     },
   });


### PR DESCRIPTION
# Summary
When a streamed Markdown document begins with a list, the parent width may not be resolved during the initial layout pass. `flex: 1` can cause the content container to receive a width of zero, leaving list markers visible while item text is clipped. `flexShrink: 1` preserves intrinsic content measurement while still allowing text to shrink and wrap when constrained.

# Changes
Replace `flex: 1` with `flexShrink: 1` for list item and task list content containers.