### PR TITLE
Release v0.12.4

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,19 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Release tag to validate and verify
+        description: Release tag to validate without publishing
         required: true
         type: string
       npm_dist_tag:
-        description: npm dist-tag to publish or verify
+        description: npm dist-tag to validate without publishing
         required: false
         default: latest
         type: string
-      publish:
-        description: Publish the package for an existing release tag (use only for release recovery)
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -178,7 +173,7 @@ jobs:
 
   publish:
     name: Publish package
-    if: ${{ (github.event_name == 'release' || inputs.publish == true) && needs.validate.outputs.already_published != 'true' }}
+    if: ${{ github.event_name == 'release' && needs.validate.outputs.already_published != 'true' }}
     needs: validate
     runs-on: ubuntu-latest
     permissions:
@@ -260,7 +255,7 @@ jobs:
 
   verify:
     name: Verify public registry
-    if: ${{ always() && needs.validate.result == 'success' && (github.event_name == 'release' || inputs.publish == true) }}
+    if: ${{ always() && needs.validate.result == 'success' && github.event_name == 'release' }}
     needs: [validate, publish]
     runs-on: ubuntu-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Breaking changes are always listed first in each release section** so upgrades
 stay safe.
 
+## [0.12.4] - 2026-09-10
+
+### Breaking changes
+
+None.
+
+### Fixed
+
+- iOS builds using static frameworks and source-built React Native now resolve
+  Folly and React Native headers when compiling the Nitro Swift/C++ bridge.
+
 ## [0.12.3] - 2026-09-08
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ None.
 
 - iOS builds using static frameworks and source-built React Native now resolve
   Folly and React Native headers when compiling the Nitro Swift/C++ bridge.
+- List-first streaming content no longer collapses inside shrink-wrapped
+  containers. List and task-list content still fills the available width in
+  constrained layouts, including nested items and block content.
 
 ## [0.12.3] - 2026-09-08
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ package and its native peer dependencies, run `expo prebuild` and use an Expo
 development build. See the [Installation guide](https://github.com/JoaoPauloCMarra/react-native-nitro-markdown/blob/main/docs/installation.md)
 for the Expo and bare React Native setup.
 
+iOS static frameworks are supported with source-built React Native. After
+upgrading, regenerate the Expo native project or run `pod install`, then rebuild
+the app so CocoaPods applies the updated header paths.
+
 ## Quick Start
 
 ```tsx

--- a/apps/example/app/_layout.tsx
+++ b/apps/example/app/_layout.tsx
@@ -107,6 +107,7 @@ function RootTabs() {
             header: () => null,
           }}
         />
+        <Tabs.Screen name="list-layout" options={{ href: null }} />
       </Tabs>
     </SafeAreaView>
   );

--- a/apps/example/app/list-layout.tsx
+++ b/apps/example/app/list-layout.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import {
+  Markdown,
+  MarkdownStream,
+  useMarkdownSession,
+} from "react-native-nitro-markdown";
+import { ExampleActionButton, ExampleHeader } from "../components/example-ui";
+import { EXAMPLE_COLORS } from "../theme";
+
+const CASES = [
+  {
+    name: "Bullet list",
+    first: "- Visible bullet text",
+    rest: " continues across several wrapped lines inside this narrow message bubble.\n- Second visible bullet\n  - Nested visible bullet",
+  },
+  {
+    name: "Ordered list",
+    first: "1. Visible ordered text",
+    rest: " continues across several wrapped lines inside this narrow message bubble.\n2. Second visible item\n   1. Nested visible item",
+  },
+  {
+    name: "Task list",
+    first: "- [ ] Visible task text",
+    rest: " continues across several wrapped lines inside this narrow message bubble.\n- [x] Completed visible task",
+  },
+  {
+    name: "Block children",
+    first: "- Short item\n\n  > Quote\n\n  ```ts\n  const x = 1;\n  ```",
+    rest: "\n\n  Second paragraph stays inside the list item and wraps at the available width.",
+  },
+] as const;
+
+type ListCaseProps = {
+  item: (typeof CASES)[number];
+};
+
+function ListCase({ item }: ListCaseProps) {
+  const session = useMarkdownSession();
+  const [stage, setStage] = useState(0);
+  const [width, setWidth] = useState(0);
+  const text = [item.first, item.rest].slice(0, stage).join("");
+
+  function append() {
+    if (stage === 2) return;
+    session.getSession().append(stage === 0 ? item.first : item.rest);
+    setStage((current) => current + 1);
+  }
+
+  return (
+    <>
+      <ExampleActionButton onPress={append}>
+        Append list tokens
+      </ExampleActionButton>
+      <Text style={styles.label}>
+        {["Waiting for tokens", "First tokens", "All tokens appended"][stage]}
+      </Text>
+      <Text style={styles.label}>Streaming in a shrink-wrapped message</Text>
+      <View style={styles.messageColumn}>
+        <View
+          onLayout={(event) => setWidth(event.nativeEvent.layout.width)}
+          style={styles.message}
+          testID="list-stream-bubble"
+        >
+          <MarkdownStream session={session} />
+        </View>
+      </View>
+      <Text style={styles.label} testID="list-stream-layout">
+        {`Shrink-wrap layout: ${width >= 120 ? "PASS" : "COLLAPSED"} (${Math.round(width)} px)`}
+      </Text>
+      <Text style={styles.label}>Static rendering at a fixed width</Text>
+      <View style={styles.fixedMessage}>
+        <Markdown>{text}</Markdown>
+      </View>
+    </>
+  );
+}
+
+function ListLayoutScreen() {
+  const [caseIndex, setCaseIndex] = useState(0);
+  const item = CASES[caseIndex] ?? CASES[0];
+
+  return (
+    <ScrollView contentContainerStyle={styles.screen}>
+      <ExampleHeader
+        title="List layout regression"
+        subtitle="List-first tokens, wrapping, and nested items"
+      />
+      <ExampleActionButton
+        onPress={() => setCaseIndex((index) => (index + 1) % CASES.length)}
+      >
+        Next list case
+      </ExampleActionButton>
+      <Text style={styles.title}>{item.name}</Text>
+      <ListCase key={item.name} item={item} />
+    </ScrollView>
+  );
+}
+
+export default ListLayoutScreen;
+
+const styles = StyleSheet.create({
+  screen: {
+    padding: 16,
+    paddingBottom: 130,
+    gap: 12,
+    backgroundColor: EXAMPLE_COLORS.background,
+  },
+  title: { color: EXAMPLE_COLORS.text, fontSize: 20, fontWeight: "700" },
+  label: { color: EXAMPLE_COLORS.textMuted, fontSize: 14 },
+  messageColumn: { alignItems: "flex-start" },
+  message: {
+    maxWidth: 280,
+    backgroundColor: EXAMPLE_COLORS.surface,
+    borderColor: EXAMPLE_COLORS.border,
+    borderWidth: 1,
+  },
+  fixedMessage: {
+    width: 280,
+    backgroundColor: EXAMPLE_COLORS.surface,
+    borderColor: EXAMPLE_COLORS.border,
+    borderWidth: 1,
+  },
+});

--- a/maestro/list-layout.yaml
+++ b/maestro/list-layout.yaml
@@ -1,0 +1,51 @@
+appId: com.nitromarkdown.example
+name: List-first streaming layout
+---
+- stopApp
+- launchApp
+- extendedWaitUntil:
+    visible: "Run Benchmark"
+    timeout: 30000
+- openLink: "nitromarkdown://list-layout"
+- extendedWaitUntil:
+    visible: "Bullet list"
+    timeout: 30000
+- tapOn: "Append list tokens"
+- extendedWaitUntil:
+    visible:
+      id: "list-stream-layout"
+      text: "Shrink-wrap layout: PASS.*"
+    timeout: 10000
+- tapOn: "Append list tokens"
+- assertVisible: "All tokens appended"
+- assertVisible: "Nested visible bullet"
+- tapOn: "Next list case"
+- assertVisible: "Ordered list"
+- tapOn: "Append list tokens"
+- extendedWaitUntil:
+    visible:
+      id: "list-stream-layout"
+      text: "Shrink-wrap layout: PASS.*"
+    timeout: 10000
+- tapOn: "Append list tokens"
+- assertVisible: "Nested visible item"
+- tapOn: "Next list case"
+- assertVisible: "Task list"
+- tapOn: "Append list tokens"
+- extendedWaitUntil:
+    visible:
+      id: "list-stream-layout"
+      text: "Shrink-wrap layout: PASS.*"
+    timeout: 10000
+- tapOn: "Append list tokens"
+- assertVisible: "Completed visible task"
+- tapOn: "Next list case"
+- assertVisible: "Block children"
+- tapOn: "Append list tokens"
+- extendedWaitUntil:
+    visible:
+      id: "list-stream-layout"
+      text: "Shrink-wrap layout: PASS.*"
+    timeout: 10000
+- assertVisible: "Quote"
+- assertVisible: "const x = 1;.*"

--- a/packages/react-native-nitro-markdown/package.json
+++ b/packages/react-native-nitro-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-markdown",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Fast native Markdown parser and renderer for React Native \u2014 CommonMark + GFM, streaming, headless AST, and math, powered by Nitro Modules and md4c",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-markdown/react-native-nitro-markdown.podspec
+++ b/packages/react-native-nitro-markdown/react-native-nitro-markdown.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
       "$(PODS_TARGET_SRCROOT)/cpp/bindings",
       "$(PODS_TARGET_SRCROOT)/nitrogen/generated/shared/c++",
       "$(PODS_TARGET_SRCROOT)/nitrogen/generated/ios"
-    ]
+    ].map { |path| "\"#{path}\"" }.join(" ")
   }
 
   s.dependency "React-Core"
@@ -44,4 +44,5 @@ Pod::Spec.new do |s|
 
   load 'nitrogen/generated/ios/NitroMarkdown+autolinking.rb'
   add_nitrogen_files(s)
+  install_modules_dependencies(s)
 end

--- a/packages/react-native-nitro-markdown/src/renderers/list.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/list.tsx
@@ -126,7 +126,7 @@ const createListItemStyles = (theme: MarkdownTheme) =>
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
     listItemContent: {
-      flex: 1,
+      flexShrink: 1,
       minWidth: 0,
     },
   });
@@ -161,7 +161,7 @@ const createTaskListItemStyles = (theme: MarkdownTheme) =>
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
     taskContent: {
-      flex: 1,
+      flexShrink: 1,
       minWidth: 0,
     },
   });

--- a/packages/react-native-nitro-markdown/src/renderers/list.tsx
+++ b/packages/react-native-nitro-markdown/src/renderers/list.tsx
@@ -126,6 +126,7 @@ const createListItemStyles = (theme: MarkdownTheme) =>
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
     listItemContent: {
+      flexGrow: 1,
       flexShrink: 1,
       minWidth: 0,
     },
@@ -161,6 +162,7 @@ const createTaskListItemStyles = (theme: MarkdownTheme) =>
       ...(Platform.OS === "android" && { includeFontPadding: false }),
     },
     taskContent: {
+      flexGrow: 1,
       flexShrink: 1,
       minWidth: 0,
     },


### PR DESCRIPTION
# Summary

Fix iOS compilation with static frameworks and source-built React Native, and prevent list-first streaming content from collapsing in react-native-nitro-markdown 0.12.4.

# Changes

- Apply React Native dependency configuration after Nitro autolinking and preserve quoted header search paths for the Swift/C++ bridge.
- Include PR #79 and retain flexGrow alongside flexShrink so list and task-list content stays visible in shrink-wrapped containers while still filling constrained rows.
- Add a deterministic native fixture and smoke flow for list-first streaming, wrapping, nested items, and block content.
- Limit live npm publishing to GitHub Release events; keep manual runs validation-only.
- Update the patch version, changelog, and iOS rebuild guidance.
